### PR TITLE
chore: use https git submodule urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "test_deps/iden3-circuits-authV2"]
 	path = test_deps/iden3-circuits-authV2
-	url = git@github.com:iden3/circuits.git
+	url = https://github.com/iden3/circuits.git
 [submodule "test_deps/iden3-circuits-master"]
 	path = test_deps/iden3-circuits-master
-	url = git@github.com:iden3/circuits.git
+	url = https://github.com/iden3/circuits.git
 [submodule "test_deps/circomlib"]
 	path = test_deps/circomlib
-	url = git@github.com:iden3/circomlib.git
+	url = https://github.com/iden3/circomlib.git


### PR DESCRIPTION
Right now adding this repo as a git dependence in a `Cargo.toml` fails due to authentication errors. This change uses unauthenticated URLs for submodules.

```
Updating git repository `https://github.com/chancehudson/circom-witnesscalc.git`
    Updating git submodule `git@github.com:iden3/circomlib.git`
error: failed to get `circom-witnesscalc` as a dependency of package `mopro-ffi v0.1.0 (/Users/chance/work/mopro/mopro-ffi)`

Caused by:
  failed to load source for dependency `circom-witnesscalc`

Caused by:
  Unable to update https://github.com/chancehudson/circom-witnesscalc.git?branch=submodule-url

Caused by:
  failed to update submodule `test_deps/circomlib`

Caused by:
  failed to fetch submodule `test_deps/circomlib` from git@github.com:iden3/circomlib.git

Caused by:
  failed to authenticate when downloading repository

  * attempted ssh-agent authentication, but no usernames succeeded: `git`

  if the git CLI succeeds then `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  no authentication methods succeeded
  ```