### PR TITLE
Enhance build script for Android support by setting CC and CLANG_PATH…

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,29 @@
-use std::io::Result;
 use std::env;
+use std::io::Result;
 use std::path::{Path, PathBuf};
 
 fn main() -> Result<()> {
+    if let Ok(target_os) = std::env::var("CARGO_CFG_TARGET_OS") {
+        if target_os == "android" {
+            let target = std::env::var("TARGET").expect("TARGET is not set");
+            let cc_target = format!("CC_{}", target);
+            if let Ok(clang_path) = std::env::var(cc_target) {
+                std::env::set_var("CC", clang_path.clone());
+                std::env::set_var("CLANG_PATH", clang_path.clone());
+            } else {
+                if let Ok(_cc_path) = std::env::var("CC") {
+                } else {
+                    panic!("Please run with cargo-ndk or set CC environment variable");
+                }
+
+                if let Ok(_clang_path) = std::env::var("CLANG_PATH") {
+                } else {
+                    panic!("Please run with cargo-ndk or set CLANG_PATH environment variable");
+                }
+            }
+        }
+    }
+
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
     // the resulting bindings.


### PR DESCRIPTION
… environment variables. Added error handling for missing variables to ensure proper configuration.

1. checks if `CC` and `CLANG_PATH` is set when building for Android
2. when users use [`cargo-ndk`](https://github.com/bbqsrc/cargo-ndk), they don't have to setup `CC` and `CLANG_PATH`
    the usage is like
    ```sh
    cargo ndk -t aarch64-linux-android build --release
    ```
    ```sh
    cargo ndk -t x86_64-linux-android build --release
    ```