### PR TITLE
refactor: extract circom dependencies into workspace extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "ark-bn254"
@@ -436,6 +436,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-circuit"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "circom-witnesscalc",
+ "code_producers",
+ "compiler 2.1.9",
+ "constraint_generation",
+ "indicatif",
+ "parser",
+ "program_structure",
+ "ruint",
+ "type_analysis",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,16 +500,11 @@ dependencies = [
  "ark-serialize 0.5.0",
  "bindgen",
  "byteorder",
- "code_producers",
- "compiler",
- "constraint_generation",
  "indicatif",
  "libc",
  "memmap2",
  "num-bigint",
  "num-traits",
- "parser",
- "program_structure",
  "prost",
  "prost-build",
  "rand 0.8.5",
@@ -501,7 +512,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "type_analysis",
  "wtns-file",
 ]
 
@@ -558,6 +568,19 @@ dependencies = [
 
 [[package]]
 name = "compiler"
+version = "0.1.0"
+dependencies = [
+ "circom-witnesscalc",
+ "compiler 2.1.9",
+ "constraint_generation",
+ "parser",
+ "program_structure",
+ "ruint",
+ "type_analysis",
+]
+
+[[package]]
+name = "compiler"
 version = "2.1.9"
 source = "git+https://github.com/olomix/circom.git?branch=master#22de6cb3200ed673c53201d9007ecdf21013783a"
 dependencies = [
@@ -593,7 +616,7 @@ source = "git+https://github.com/olomix/circom.git?branch=master#22de6cb3200ed67
 dependencies = [
  "ansi_term",
  "circom_algebra",
- "compiler",
+ "compiler 2.1.9",
  "constraint_list",
  "constraint_writers",
  "dag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "circom-witnesscalc"
 version = "0.2.0"
 edition = "2021"
 repository = "https://github.com/iden3/circom-witnesscalc"
+authors = ["Oleh Lomaka <oleg.lomaka@gmail.com>"]
+description = "Witness calculator for Circom circuits"
+license = "MIT OR Apache-2.0"
 
 [features]
 default = []
@@ -28,12 +31,6 @@ libc = "0.2.155"
 #parser = { path = "../circom/parser" }
 #type_analysis = { path = "../circom/type_analysis" }
 #constraint_generation = { path = "../circom/constraint_generation" }
-compiler = { git = "https://github.com/olomix/circom.git", branch = "master" }
-code_producers = { git = "https://github.com/olomix/circom.git", branch = "master" }
-program_structure = { git = "https://github.com/olomix/circom.git", branch = "master" }
-parser = { git = "https://github.com/olomix/circom.git", branch = "master" }
-type_analysis = { git = "https://github.com/olomix/circom.git", branch = "master" }
-constraint_generation = { git = "https://github.com/olomix/circom.git", branch = "master" }
 prost = "0.13.1"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
@@ -54,3 +51,6 @@ crate-type = ["lib", "staticlib", "cdylib"]
 [build-dependencies]
 bindgen = "0.70.1"
 prost-build = "0.13.3"
+
+[workspace]
+members = ["extensions/build-circuit", "extensions/compiler"]

--- a/extensions/build-circuit/Cargo.toml
+++ b/extensions/build-circuit/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "build-circuit"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1.0.98"
+compiler = { git = "https://github.com/olomix/circom.git", branch = "master" }
+constraint_generation = { git = "https://github.com/olomix/circom.git", branch = "master" }
+program_structure = { git = "https://github.com/olomix/circom.git", branch = "master" }
+code_producers = { git = "https://github.com/olomix/circom.git", branch = "master" }
+type_analysis = { git = "https://github.com/olomix/circom.git", branch = "master" }
+parser = { git = "https://github.com/olomix/circom.git", branch = "master" }
+indicatif = "0.17.11"
+ruint = { version = "1.13.1", features = ["rand", "serde", "num-traits"] }
+circom-witnesscalc = { path = "../.." }
+
+

--- a/extensions/compiler/Cargo.toml
+++ b/extensions/compiler/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "compiler"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+compiler = { git = "https://github.com/olomix/circom.git", branch = "master" }
+constraint_generation = { git = "https://github.com/olomix/circom.git", branch = "master" }
+program_structure = { git = "https://github.com/olomix/circom.git", branch = "master" }
+ruint = { version = "1.13.1", features = ["rand", "serde", "num-traits"] }
+type_analysis = { git = "https://github.com/olomix/circom.git", branch = "master" }
+circom-witnesscalc = { path = "../.." }
+parser = { git = "https://github.com/olomix/circom.git", branch = "master" }

--- a/src/bin/calc-witness-vm.rs
+++ b/src/bin/calc-witness-vm.rs
@@ -5,11 +5,10 @@ use std::cell::RefCell;
 use std::io::Write;
 use std::rc::Rc;
 use std::time::Instant;
-use code_producers::c_elements::{InputList};
 use ruint::aliases::U256;
 use circom_witnesscalc::{wtns_from_u256_witness, Error};
 use circom_witnesscalc::Error::InputsUnmarshal;
-use circom_witnesscalc::storage::deserialize_witnesscalc_vm;
+use circom_witnesscalc::storage::{deserialize_witnesscalc_vm, InputList};
 use circom_witnesscalc::vm::{build_component, execute, Template};
 
 struct Args {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -11,8 +11,6 @@ use crate::field::{Field, FieldOperations, FieldOps, M};
 use rand::{RngCore};
 use ruint::aliases::U256;
 use serde::{Deserialize, Serialize};
-
-use compiler::intermediate_representation::ir_interface::OperatorType;
 use memmap2::MmapMut;
 use rand::prelude::ThreadRng;
 use ruint::uint;
@@ -111,41 +109,6 @@ impl From<&Operation> for crate::proto::DuoOp {
     }
 }
 
-impl TryFrom<OperatorType> for Operation {
-    type Error = String;
-    fn try_from(op: OperatorType) -> Result<Self, Self::Error> {
-        match op {
-            OperatorType::Mul => Ok(Operation::Mul),
-            OperatorType::Div => Ok(Operation::Div),
-            OperatorType::Add => Ok(Operation::Add),
-            OperatorType::Sub => Ok(Operation::Sub),
-            OperatorType::Pow => Ok(Operation::Pow),
-            OperatorType::IntDiv => Ok(Operation::Idiv),
-            OperatorType::Mod => Ok(Operation::Mod),
-            OperatorType::ShiftL => Ok(Operation::Shl),
-            OperatorType::ShiftR => Ok(Operation::Shr),
-            OperatorType::LesserEq => Ok(Operation::Leq),
-            OperatorType::GreaterEq => Ok(Operation::Geq),
-            OperatorType::Lesser => Ok(Operation::Lt),
-            OperatorType::Greater => Ok(Operation::Gt),
-            OperatorType::Eq(1) => Ok(Operation::Eq),
-            OperatorType::Eq(_) => todo!(),
-            OperatorType::NotEq => Ok(Operation::Neq),
-            OperatorType::BoolOr => Ok(Operation::Lor),
-            OperatorType::BoolAnd => Ok(Operation::Land),
-            OperatorType::BitOr => Ok(Operation::Bor),
-            OperatorType::BitAnd => Ok(Operation::Band),
-            OperatorType::BitXor => Ok(Operation::Bxor),
-            OperatorType::PrefixSub => Err("Not a binary operation".to_string()),
-            OperatorType::BoolNot => Err("Not a binary operation".to_string()),
-            OperatorType::Complement => Err("Not a binary operation".to_string()),
-            OperatorType::ToAddress => Err("Not a binary operation".to_string()),
-            OperatorType::MulAddress => Ok(Operation::Mul),
-            OperatorType::AddAddress => Ok(Operation::Add),
-        }
-    }
-}
-
 impl TryFrom<u8> for Operation {
     type Error = String;
 
@@ -238,42 +201,6 @@ impl From<&UnoOperation> for crate::proto::UnoOp {
             UnoOperation::Id => crate::proto::UnoOp::Id,
             UnoOperation::Lnot => crate::proto::UnoOp::Lnot,
             UnoOperation::Bnot => crate::proto::UnoOp::Bnot,
-        }
-    }
-}
-
-impl TryFrom<OperatorType> for UnoOperation {
-    type Error = String;
-    fn try_from(op: OperatorType) -> Result<Self, Self::Error> {
-        let err = Err("Not an unary operation".to_string());
-        match op {
-            OperatorType::Mul => err,
-            OperatorType::Div => err,
-            OperatorType::Add => err,
-            OperatorType::Sub => err,
-            OperatorType::Pow => err,
-            OperatorType::IntDiv => err,
-            OperatorType::Mod => err,
-            OperatorType::ShiftL => err,
-            OperatorType::ShiftR => err,
-            OperatorType::LesserEq => err,
-            OperatorType::GreaterEq => err,
-            OperatorType::Lesser => err,
-            OperatorType::Greater => err,
-            OperatorType::Eq(1) => err,
-            OperatorType::Eq(_) => err,
-            OperatorType::NotEq => err,
-            OperatorType::BoolOr => err,
-            OperatorType::BoolAnd => err,
-            OperatorType::BitOr => err,
-            OperatorType::BitAnd => err,
-            OperatorType::BitXor => err,
-            OperatorType::PrefixSub => Ok(UnoOperation::Neg),
-            OperatorType::BoolNot => Ok(UnoOperation::Lnot),
-            OperatorType::Complement => Ok(UnoOperation::Bnot),
-            OperatorType::ToAddress => Ok(UnoOperation::Id),
-            OperatorType::MulAddress => err,
-            OperatorType::AddAddress => err,
         }
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,10 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 #[cfg(test)]
 use std::fmt::{Debug, Formatter};
 use std::io::{Error, ErrorKind, Read, Write};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use code_producers::c_elements::InputList;
-use code_producers::components::{IODef, TemplateInstanceIOMap};
 use prost::Message;
 use ruint::aliases::U256;
 use crate::field::{FieldOps, U254};
@@ -128,6 +126,18 @@ pub fn serialize_witnesscalc_graph<W, T, NS>(
 
     Ok(())
 }
+
+pub type InputList = Vec<(String, usize, usize)>;
+
+pub struct IODef {
+    pub code: usize,
+    pub offset: usize,
+    pub lengths: Vec<usize>,
+}
+
+pub type InputOutputList = Vec<IODef>;
+
+pub type TemplateInstanceIOMap = BTreeMap<usize, InputOutputList>;
 
 pub struct CompiledCircuit {
     pub main_template_id: usize,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3,11 +3,10 @@ use std::cmp::Ordering;
 use std::fmt::{Debug, Display};
 use std::num::TryFromIntError;
 use std::rc::Rc;
-use code_producers::c_elements::TemplateInstanceIOMap;
-use compiler::intermediate_representation::ir_interface::StatusInput;
 use ruint::aliases::U256;
 use crate::field::M;
 use crate::graph::{Operation, UnoOperation};
+use crate::storage::TemplateInstanceIOMap;
 
 pub struct Component {
     pub vars: Vec<Option<U256>>,
@@ -425,16 +424,6 @@ impl TryFrom<u8> for InputStatus {
             1 => Ok(InputStatus::NoLast),
             2 => Ok(InputStatus::Unknown),
             _ => Err(()),
-        }
-    }
-}
-
-impl From<&StatusInput> for InputStatus {
-    fn from(status: &StatusInput) -> Self {
-        match status {
-            StatusInput::Last => InputStatus::Last,
-            StatusInput::NoLast => InputStatus::NoLast,
-            StatusInput::Unknown => InputStatus::Unknown,
         }
     }
 }

--- a/test_circuits.sh
+++ b/test_circuits.sh
@@ -93,7 +93,7 @@ for arg in "${library_paths[@]}"; do
 done
 
 pushd "${script_dir}" > /dev/null
-cargo build --release
+cargo build --release --workspace
 popd > /dev/null
 
 function test_circuit() {

--- a/test_circuits_vm.sh
+++ b/test_circuits_vm.sh
@@ -93,7 +93,7 @@ for arg in "${library_paths[@]}"; do
 done
 
 pushd "${script_dir}" > /dev/null
-cargo build --release
+cargo build --release --workspace
 popd > /dev/null
 
 function test_circuit() {


### PR DESCRIPTION
- Move build-circuit and compiler binaries into separate workspace crates under extensions/
- Remove direct circom dependencies from main crate to reduce coupling
- Create workspace structure with extensions/build-circuit and extensions/compiler
- Move circom-specific type conversions (OperatorType, StatusInput) into build-circuit
- Relocate IODef and TemplateInstanceIOMap types to storage module
- Update build scripts to build entire workspace
- Add package metadata (authors, description, license) to main Cargo.toml