### PR TITLE
CVM (Circom Virtual Machine) parser and execution engine as an alternative to WASM-based witness calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ circuit.cc
 constants.dat
 .idea
 /test_working_dir
+/test_working_dir_vm2
 /experiments

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "type_analysis",
+ "winnow",
  "wtns-file",
 ]
 
@@ -2352,9 +2353,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.0"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.12",
  "type_analysis",
  "winnow",
  "wtns-file",
@@ -1338,7 +1339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
@@ -1978,11 +1979,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1998,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ indicatif = "0.17.11"
 memmap2 = "0.9.5"
 tempfile = "3.19.1"
 winnow = "0.7.7"
+thiserror = "2.0.12"
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ anyhow = "1.0.97"
 indicatif = "0.17.11"
 memmap2 = "0.9.5"
 tempfile = "3.19.1"
+winnow = "0.7.7"
 
 [profile.release]
 opt-level = 3

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -239,6 +239,11 @@ pub enum Statement {
         sig_idx: I64Operand,
         value: FfExpr
     },
+    SetCmpInput {
+        cmp_idx: I64Expr,
+        sig_idx: I64Expr,
+        value: FfExpr
+    },
     Error { code: I64Operand },
     Branch {
         condition: Expr,
@@ -289,6 +294,8 @@ pub enum FfExpr {
 pub enum I64Expr {
     Variable(String),
     Literal(i64),
+    Add(Box<I64Expr>, Box<I64Expr>),
+    Sub(Box<I64Expr>, Box<I64Expr>),
 }
 
 #[cfg_attr(test, derive(PartialEq, Debug))]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -214,14 +214,21 @@ pub struct Template {
 
 #[cfg_attr(test, derive(PartialEq, Debug))]
 pub enum TemplateInstruction {
-    Assignment(Assignment),
+    FfAssignment(FfAssignment),
+    I64Assignment(I64Assignment),
     Statement(Statement),
 }
 
 #[cfg_attr(test, derive(PartialEq, Debug))]
-pub struct Assignment {
+pub struct FfAssignment {
     pub dest: String,
     pub value: FfExpr,
+}
+
+#[cfg_attr(test, derive(PartialEq, Debug))]
+pub struct I64Assignment {
+    pub dest: String,
+    pub value: I64Expr,
 }
 
 #[cfg_attr(test, derive(PartialEq, Debug))]
@@ -237,7 +244,10 @@ pub enum Statement {
         condition: FfExpr,
         if_block: Vec<TemplateInstruction>,
         else_block: Vec<TemplateInstruction>
-    }
+    },
+    Loop(Vec<TemplateInstruction>),
+    Break,
+    Continue,
 }
 
 #[cfg_attr(test, derive(PartialEq, Debug, Clone))]
@@ -268,6 +278,12 @@ pub enum FfExpr {
     FfEqz(Box<FfExpr>),
     Variable(String),
     Literal(BigUint),
+}
+
+#[cfg_attr(test, derive(PartialEq, Debug, Clone))]
+pub enum I64Expr {
+    Variable(String),
+    Literal(i64),
 }
 
 #[cfg_attr(test, derive(PartialEq, Debug))]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -221,24 +221,29 @@ pub enum TemplateInstruction {
 #[cfg_attr(test, derive(PartialEq, Debug))]
 pub struct Assignment {
     pub dest: String,
-    pub value: Expr,
+    pub value: FfExpr,
 }
 
 #[cfg_attr(test, derive(PartialEq, Debug))]
 pub enum Statement {
-    SetSignal { idx: I64Operand, value: FfOperand }
+    SetSignal { idx: I64Operand, value: FfExpr },
+    SetCmpSignalRun {
+        cmp_idx: I64Operand,
+        sig_idx: I64Operand,
+        value: FfExpr
+    },
+    Error { code: I64Operand },
+    Branch {
+        condition: FfExpr,
+        if_block: Vec<TemplateInstruction>,
+        else_block: Vec<TemplateInstruction>
+    }
 }
 
-#[cfg_attr(test, derive(PartialEq, Debug))]
+#[cfg_attr(test, derive(PartialEq, Debug, Clone))]
 pub enum I64Operand {
     Variable(String),
     Literal(i64),
-}
-
-#[cfg_attr(test, derive(PartialEq, Debug))]
-pub enum FfOperand {
-    Variable(String),
-    Literal(BigUint),
 }
 
 pub enum UnoOp {
@@ -250,17 +255,24 @@ pub enum UnoOp {
 }
 
 
-#[cfg_attr(test, derive(PartialEq, Debug))]
-pub enum Expr {
+#[cfg_attr(test, derive(PartialEq, Debug, Clone))]
+pub enum FfExpr {
     GetSignal(I64Operand),
-    FfAdd(FfOperand, FfOperand),
-    FfMul(FfOperand, FfOperand),
-    FfNeq(FfOperand, FfOperand),
+    GetCmpSignal{ cmp_idx: I64Operand, sig_idx: I64Operand },
+    FfAdd(Box<FfExpr>, Box<FfExpr>),
+    FfMul(Box<FfExpr>, Box<FfExpr>),
+    FfNeq(Box<FfExpr>, Box<FfExpr>),
+    FfDiv(Box<FfExpr>, Box<FfExpr>),
+    FfSub(Box<FfExpr>, Box<FfExpr>),
+    FfEq(Box<FfExpr>, Box<FfExpr>),
+    FfEqz(Box<FfExpr>),
+    Variable(String),
+    Literal(BigUint),
 }
 
 #[cfg_attr(test, derive(PartialEq, Debug))]
 pub enum Signal {
-    Ff(Vec<usize>),         // dimensions
+    Ff(Vec<usize>),          // dimensions
     Bus(String, Vec<usize>), // bus name and dimensions
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -255,6 +255,7 @@ pub enum Expr {
     GetSignal(I64Operand),
     FfAdd(FfOperand, FfOperand),
     FfMul(FfOperand, FfOperand),
+    FfNeq(FfOperand, FfOperand),
 }
 
 #[cfg_attr(test, derive(PartialEq, Debug))]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -241,7 +241,7 @@ pub enum Statement {
     },
     Error { code: I64Operand },
     Branch {
-        condition: FfExpr,
+        condition: Expr,
         if_block: Vec<TemplateInstruction>,
         else_block: Vec<TemplateInstruction>
     },
@@ -264,6 +264,11 @@ pub enum UnoOp {
     // Bnot,
 }
 
+#[cfg_attr(test, derive(PartialEq, Debug))]
+pub enum Expr {
+    Ff(FfExpr),
+    I64(I64Expr),
+}
 
 #[cfg_attr(test, derive(PartialEq, Debug, Clone))]
 pub enum FfExpr {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,0 +1,281 @@
+// AST definitions for Circom assembly language
+// Refined with full instruction set from circom-virtual-machine.md
+
+use num_bigint::BigUint;
+
+// /// Top-level AST node
+// #[derive(Debug)]
+// pub enum AstNode {
+//     Directive(Directive),
+//     Template(Template),
+// }
+//
+// /// Assembly directives (lines starting with `%%`)
+// #[derive(Debug)]
+// pub enum Directive {
+//     Prime(BigUint),                       // %%prime
+//     Signals(usize),                       // %%signals
+//     ComponentsHeap(usize),                // %%components_heap
+//     Start(String),                        // %%start
+//     ComponentsMode(ComponentsMode),       // %%components
+//     Witness(Vec<usize>),                  // %%witness
+//     Types(Vec<TypeDef>),                  // %%types definitions
+// }
+//
+// /// Component creation mode
+// #[derive(Debug)]
+// pub enum ComponentsMode {
+//     Implicit,
+//     Explicit,
+// }
+//
+// /// Optional type definitions for fields/signals
+// #[derive(Debug)]
+// pub struct TypeDef {
+//     pub name: String,
+//     pub ty: String,
+//     pub offset: usize,
+//     pub size: usize,
+//     pub dims: Vec<usize>,
+// }
+//  
+// /// A template (`%%template` block)
+// #[derive(Debug)]
+// pub struct Template {
+//     pub name: String,                    // Template name
+//     pub ff_inputs: Vec<Literal>,         // Constants/refs, e.g. ff./i64.
+//     pub ff_outputs: Vec<Literal>,
+//     pub signals: Vec<Literal>,           // signal counts
+//     pub extra: Vec<String>,              // extra metadata or dims
+//     pub body: Vec<Instruction>,          // Sequence of instructions
+// }
+//
+// /// Individual instructions
+// #[derive(Debug)]
+// pub enum Instruction {
+//     // Arithmetic operations
+//     /// i64.add, i64.sub, i64.mul, i64.div, i64.rem
+//     I64Op { op: I64Op, args: Vec<Expr>, dest: String },
+//     /// ff.add, ff.sub, ff.mul, ff.idiv, ff.div, ff.rem, ff.pow, 64.pow
+//     FfOp  { op: FfOp,  args: Vec<Expr>, dest: String },
+//
+//     // Relational operations
+//     I64RelOp{ op: I64RelOp, args: Vec<Expr>, dest: String },
+//     FfRelOp { op: FfRelOp,  args: Vec<Expr>, dest: String },
+//
+//     // Boolean operations
+//     I64BoolOp{ op: I64BoolOp, args: Vec<Expr>, dest: String },
+//     FfBoolOp { op: FfBoolOp,  args: Vec<Expr>, dest: String },
+//
+//     // Bit operations
+//     I64BitOp { op: I64BitOp, args: Vec<Expr>, dest: String },
+//     FfBitOp  { op: FfBitOp,  args: Vec<Expr>, dest: String },
+//
+//     // Conversions: extend_ff, wrap_i64
+//     Convert  { op: ConvertOp, arg: Box<Expr>, dest: String },
+//
+//     // Memory operations
+//     I64Load  { dest: String, addr: Box<Expr> },             // i64.load
+//     FfLoad   { dest: String, addr: Box<Expr> },             // ff.load
+//     I64Store { addr: Box<Expr>, value: Box<Expr> },         // i64.store
+//     FfStore  { addr: Box<Expr>, value: Box<Expr> },         // ff.store
+//     FfMstore { dest_addr: Box<Expr>, src_addr: Box<Expr>, size: Box<Expr> },
+//     FfMstoreFromSignal    { dest_addr: Box<Expr>, signal_idx: Box<Expr>, size: Box<Expr> },
+//     FfMstoreFromCmpSignal { dest_addr: Box<Expr>, cmp_idx: Box<Expr>, signal_idx: Box<Expr>, size: Box<Expr> },
+//
+//     // Signal memory operations
+//     GetSignal                { dest: String, idx: Expr },
+//     GetCmpSignal             { dest: String, cmp: Expr, idx: Expr },
+//     SetSignal                { idx: Expr, value: Expr },
+//     MsetSignal               { dest: Expr, src: Expr, size: Expr },
+//     MsetSignalFromMemory     { dest: Expr, addr: Expr, size: Expr },
+//     SetCmpInput              { cmp: Expr, idx: Expr, value: Expr },
+//     MsetCmpInput             { cmp: Expr, dest: Expr, src: Expr, size: Expr },
+//     MsetCmpInputCnt          { cmp: Expr, dest: Expr, src: Expr, size: Expr },
+//     MsetCmpInputRun          { cmp: Expr, dest: Expr, src: Expr, size: Expr },
+//     MsetCmpInputCntCheck     { cmp: Expr, dest: Expr, src: Expr, size: Expr },
+//     MsetCmpInputFromCmp      { cmp1: Expr, sidx1: Expr, cmp2: Expr, sidx2: Expr, size: Expr },
+//     MsetCmpInputFromCmpCnt   { cmp1: Expr, sidx1: Expr, cmp2: Expr, sidx2: Expr, size: Expr },
+//     MsetCmpInputFromCmpRun   { cmp1: Expr, sidx1: Expr, cmp2: Expr, sidx2: Expr, size: Expr },
+//     MsetCmpInputFromCmpCntCheck { cmp1: Expr, sidx1: Expr, cmp2: Expr, sidx2: Expr, size: Expr },
+//     MsetCmpInputFromMemory   { cmp: Expr, sidx: Expr, addr: Expr, size: Expr },
+//     MsetCmpInputFromMemoryCnt { cmp: Expr, sidx: Expr, addr: Expr, size: Expr },
+//     MsetCmpInputFromMemoryRun { cmp: Expr, sidx: Expr, addr: Expr, size: Expr },
+//     MsetCmpInputFromMemoryCntCheck { cmp: Expr, sidx: Expr, addr: Expr, size: Expr },
+//
+//     // Control flow
+//     Loop    { body: Vec<Instruction> },
+//     Break,
+//     Continue,
+//     If      { cond: Expr, then_branch: Vec<Instruction>, else_branch: Option<Vec<Instruction>> },
+//
+//     // Function calls and returns
+//     Call       { kind: CallKind, name: String, params: Vec<CallParam>, dest: Option<String> },
+//     Return     { op: ReturnOp, value: Vec<Expr> },
+//
+//     // Template/bus introspection
+//     GetTemplateId            { dest: String, subcmp: Expr },
+//     GetTemplateSignalPos     { dest: String, tmpl: Expr, sig: Expr },
+//     GetTemplateSignalSize    { dest: String, tmpl: Expr, sig: Expr },
+//     GetTemplateSignalDim     { dest: String, tmpl: Expr, sig: Expr },
+//     GetTemplateSignalType    { dest: String, tmpl: Expr, sig: Expr },
+//     GetBusSignalPos          { dest: String, bus: Expr, sig: Expr },
+//     GetBusSignalSize         { dest: String, bus: Expr, sig: Expr },
+//     GetBusSignalDim          { dest: String, bus: Expr, sig: Expr },
+//     GetBusSignalType         { dest: String, bus: Expr, sig: Expr },
+//
+//     // Misc
+//     Other(String),
+// }
+//
+// /// Expressions: signals, literals, or binary operations
+// #[derive(Debug)]
+// pub enum Expr {
+//     Signal(usize),
+//     Literal(Literal),
+//     BinaryOp { op: BinaryOp, left: Box<Expr>, right: Box<Expr> },
+// }
+
+/// Typed literal constants
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
+pub enum Literal {
+    I64(i64),    // i64.<value>
+    Ff(BigUint), // ff.<value>
+}
+
+// /// Integer arithmetic ops
+// #[derive(Debug)]
+// pub enum I64Op { Add, Sub, Mul, Div, Rem }
+//
+// /// Field arithmetic ops
+// #[derive(Debug)]
+// pub enum FfOp  { Add, Sub, Mul, IDiv, Div, Rem, Pow }
+//
+// /// Integer relational ops
+// #[derive(Debug)]
+// pub enum I64RelOp { Gt, Ge, Lt, Le, Eq, Neq, Eqz }
+//
+// /// Field relational ops
+// #[derive(Debug)]
+// pub enum FfRelOp  { Gt, Ge, Lt, Le, Eq, Neq, Eqz }
+//
+// /// Integer boolean ops
+// #[derive(Debug)]
+// pub enum I64BoolOp { And, Or }
+//
+// /// Field boolean ops
+// #[derive(Debug)]
+// pub enum FfBoolOp  { And, Or }
+//
+// /// Integer bitwise ops
+// #[derive(Debug)]
+// pub enum I64BitOp { Shr, Shl, Band, Bor, Bxor, Bnot }
+//
+// /// Field bitwise ops
+// #[derive(Debug)]
+// pub enum FfBitOp  { Shr, Shl, Band, Bor, Bxor, Bnot }
+//
+// /// Conversions
+// #[derive(Debug)]
+// pub enum ConvertOp { ExtendFf, WrapI64 }
+//
+// /// Binary operators
+// #[derive(Debug)]
+// pub enum BinaryOp { Add, Sub, Mul, Rem, Eq, Neq, Lt }
+//
+// /// Call kinds
+// #[derive(Debug)]
+// pub enum CallKind { I64, Ff, Void }
+//
+// /// Call parameter types
+// #[derive(Debug)]
+// pub enum CallParam {
+//     Expr(Expr),
+//     Signal { idx: Expr, size: Expr },
+//     CmpSignal { cmp: Expr, idx: Expr, size: Expr },
+//     I64Mem { addr: Expr, size: Expr },
+//     FfMem { addr: Expr, size: Expr },
+// }
+//
+// /// Return operation types
+// #[derive(Debug)]
+// pub enum ReturnOp { I64Return, FfReturn, Return }
+
+#[cfg_attr(test, derive(PartialEq, Debug))]
+pub struct Template {
+    pub name: String,
+    pub outputs: Vec<Signal>,
+    pub inputs: Vec<Signal>,
+    pub signals_num: usize,
+    pub components: Vec<Option<usize>>,
+    pub body: Vec<TemplateInstruction>,
+}
+
+#[cfg_attr(test, derive(PartialEq, Debug))]
+pub enum TemplateInstruction {
+    Assignment(Assignment),
+    Statement(Statement),
+}
+
+#[cfg_attr(test, derive(PartialEq, Debug))]
+pub struct Assignment {
+    pub dest: String,
+    pub value: Expr,
+}
+
+#[cfg_attr(test, derive(PartialEq, Debug))]
+pub enum Statement {
+    SetSignal { idx: I64Operand, value: FfOperand }
+}
+
+#[cfg_attr(test, derive(PartialEq, Debug))]
+pub enum I64Operand {
+    Variable(String),
+    Literal(i64),
+}
+
+#[cfg_attr(test, derive(PartialEq, Debug))]
+pub enum FfOperand {
+    Variable(String),
+    Literal(BigUint),
+}
+
+pub enum UnoOp {
+    GetSignal,
+    // Neg,
+    // Id, // identity - just return self
+    // Lnot,
+    // Bnot,
+}
+
+
+#[cfg_attr(test, derive(PartialEq, Debug))]
+pub enum Expr {
+    GetSignal(I64Operand),
+    FfAdd(FfOperand, FfOperand),
+    FfMul(FfOperand, FfOperand),
+}
+
+#[cfg_attr(test, derive(PartialEq, Debug))]
+pub enum Signal {
+    Ff(Vec<usize>),         // dimensions
+    Bus(String, Vec<usize>), // bus name and dimensions
+}
+
+#[cfg_attr(test, derive(PartialEq, Debug))]
+pub enum ComponentsMode {
+    Implicit,
+    Explicit,
+}
+
+#[cfg_attr(test, derive(PartialEq, Debug))]
+pub struct AST {
+    pub prime: BigUint,
+    pub signals: usize,
+    pub components_heap: usize,
+    pub start: String,
+    pub components_mode: ComponentsMode,
+    pub witness: Vec<usize>,
+    pub templates: Vec<Template>,
+}

--- a/src/bin/compiler.rs
+++ b/src/bin/compiler.rs
@@ -1995,7 +1995,7 @@ mod tests {
         }));
         expression(
             &inst, &mut code, &constants, &mut vec![],
-            &mut vec![]);
+            &[]);
         assert_eq!(code, vec![OpCode::Push8 as u8, 42, 0, 0, 0, 0, 0, 0, 0]);
     }
 
@@ -2010,7 +2010,7 @@ mod tests {
             op_aux_no: 0,
             value: 42,
         }));
-        expression(&inst, &mut code, &constants, &mut vec![], &mut vec![]);
+        expression(&inst, &mut code, &constants, &mut vec![], &[]);
         assert_eq!(code, vec![OpCode::GetConstant8 as u8, 42, 0, 0, 0, 0, 0, 0, 0]);
     }
 
@@ -2347,9 +2347,9 @@ STORE(
         let j = bigint_to_u64(i);
         assert!(matches!(j, Some(u64::MAX)));
 
-        i = i * uint!(2_U256);
+        i *= uint!(2_U256);
         let j = bigint_to_u64(i);
-        assert!(matches!(j, None));
+        assert!(j.is_none());
     }
 
     #[test]
@@ -2438,8 +2438,7 @@ STORE(
     #[test]
     fn test_dump() {
         let noop = OpCode::NoOp as u8;
-        let mut code = vec![];
-        code.push(noop);
+        let code = vec![noop];
         let c = Component{
             vars: vec![],
             signals_start: 0,
@@ -2460,11 +2459,11 @@ STORE(
         let mut signals = vec![None; 10];
         let io_map = BTreeMap::new();
         execute(
-            component, &templates, &vec![], &constants, &mut signals,
+            component, &templates, &[], &constants, &mut signals,
             &io_map, None);
     }
 
-    fn names_from_fn_vec(fns: &Vec<Function>) -> Vec<String> {
+    fn names_from_fn_vec(fns: &[Function]) -> Vec<String> {
         fns.iter().map(|f| f.name.clone()).collect()
     }
 

--- a/src/bin/cvm-compile.rs
+++ b/src/bin/cvm-compile.rs
@@ -1,5 +1,12 @@
-use std::env;
-use circom_witnesscalc::ast::Literal;
+use std::{env, fs};
+use std::collections::HashMap;
+use num_bigint::BigUint;
+use num_traits::{Num, ToBytes};
+use circom_witnesscalc::{ast, vm2};
+use circom_witnesscalc::ast::{Literal, Statement, AST};
+use circom_witnesscalc::field::{FieldOps, U254};
+use circom_witnesscalc::parser::parse_ast;
+use circom_witnesscalc::vm2::OpCode;
 
 struct Args {
     cvm_file: String,
@@ -54,8 +61,148 @@ fn parse_args() -> Args {
 fn main() {
     let args = parse_args();
 
-    let _x = Literal::I64(123);
+    let program_text = fs::read_to_string(&args.cvm_file).unwrap();
+    let program = parse_ast(&mut(program_text.as_str())).unwrap();
+    let bn254 = BigUint::from_str_radix("21888242871839275222246405745257275088548364400416034343698204186575808495617", 10).unwrap();
+    match &program.prime {
+        bn254 => {
+            compile::<U254>(&program);
+        }
+    }
     println!("OK {}", args.cvm_file);
+}
+
+fn compile<T>(tree: &ast::AST)
+where
+    T: FieldOps {
+
+    for t in tree.templates.iter() {
+        let compiled_template = compile_template::<T>(t);
+        println!("Template: {}", t.name);
+        println!("Compiled code len: {}", compiled_template.code.len());
+    }
+}
+
+struct TemplateCompilationContext {
+    code: Vec<u8>,
+    ff_variable_indexes: HashMap<String, i64>,
+    i64_variable_indexes: HashMap<String, i64>,
+}
+
+impl TemplateCompilationContext {
+    fn new() -> Self {
+        Self {
+            code: vec![],
+            ff_variable_indexes: HashMap::new(),
+            i64_variable_indexes: HashMap::new(),
+        }
+    }
+
+    fn get_ff_variable_index(&mut self, var_name: &str) -> i64 {
+        let next_idx = self.ff_variable_indexes.len() as i64;
+        *self.ff_variable_indexes
+            .entry(var_name.to_string()).or_insert(next_idx)
+    }
+    fn get_i64_variable_index(&mut self, var_name: &str) -> i64 {
+        let next_idx = self.i64_variable_indexes.len() as i64;
+        *self.i64_variable_indexes
+            .entry(var_name.to_string()).or_insert(next_idx)
+    }
+}
+
+fn operand_ff<T>(ctx: &mut TemplateCompilationContext, operand: &ast::FfOperand)
+where
+    T: FieldOps {
+
+    match operand {
+        ast::FfOperand::Literal(v) => {
+            ctx.code.push(OpCode::PushI64 as u8);
+            let x = T::from_le_bytes(v.to_le_bytes().as_slice()).unwrap();
+            ctx.code.extend_from_slice(x.to_le_bytes().as_slice());
+        }
+        ast::FfOperand::Variable(var_name) => {
+            let var_idx = ctx.get_ff_variable_index(var_name);
+            ctx.code.push(OpCode::LoadVariableFf as u8);
+            ctx.code.extend_from_slice(var_idx.to_le_bytes().as_slice());
+        }
+    }
+}
+
+fn operand_i64(
+    ctx: &mut TemplateCompilationContext, operand: &ast::I64Operand) {
+
+    match operand {
+        ast::I64Operand::Literal(v) => {
+            ctx.code.push(OpCode::PushI64 as u8);
+            ctx.code.extend_from_slice(v.to_le_bytes().as_slice());
+        }
+        ast::I64Operand::Variable(var_name) => {
+            let var_idx = ctx.get_i64_variable_index(var_name);
+            ctx.code.push(OpCode::LoadVariableI64 as u8);
+            ctx.code.extend_from_slice(var_idx.to_le_bytes().as_slice());
+        }
+    }
+}
+
+fn expression<T>(ctx: &mut TemplateCompilationContext, expr: &ast::Expr)
+where
+    T: FieldOps {
+
+    match expr {
+        ast::Expr::GetSignal(operand) => {
+            operand_i64(ctx, operand);
+            ctx.code.push(OpCode::LoadSignal as u8);
+        }
+        ast::Expr::FfMul(lhs, rhs) => {
+            operand_ff::<T>(ctx, rhs);
+            operand_ff::<T>(ctx, lhs);
+            ctx.code.push(OpCode::OpMul as u8);
+        },
+        ast::Expr::FfAdd(lhs, rhs) => {
+            operand_ff::<T>(ctx, rhs);
+            operand_ff::<T>(ctx, lhs);
+            ctx.code.push(OpCode::OpAdd as u8);
+        },
+    }
+}
+
+fn instruction<T>(
+    ctx: &mut TemplateCompilationContext, inst: &ast::TemplateInstruction)
+where
+    T: FieldOps {
+
+    match inst {
+        ast::TemplateInstruction::Assignment(assignment) => {
+            expression::<T>(ctx, &assignment.value);
+            ctx.code.push(OpCode::StoreVariable as u8);
+            let var_idx = ctx.get_ff_variable_index(&assignment.dest);
+            ctx.code.extend_from_slice(var_idx.to_le_bytes().as_slice());
+        }
+        ast::TemplateInstruction::Statement(statement) => {
+            match statement {
+                Statement::SetSignal { idx, value } => {
+                    operand_ff::<T>(ctx, value);
+                    operand_i64(ctx, idx);
+                    ctx.code.push(OpCode::StoreSignal as u8);
+                }
+            }
+        }
+    }
+}
+
+fn compile_template<T>(t: &ast::Template) -> vm2::Template
+where
+    T: FieldOps {
+
+    let mut ctx = TemplateCompilationContext::new();
+    for i in &t.body {
+        instruction::<T>(&mut ctx, &i);
+    }
+
+    vm2::Template {
+        name: t.name.clone(),
+        code: ctx.code,
+    }
 }
 
 #[cfg(test)]

--- a/src/bin/cvm-compile.rs
+++ b/src/bin/cvm-compile.rs
@@ -1,0 +1,18 @@
+
+use circom_witnesscalc::vm::ComponentTmpl;
+use circom_witnesscalc::ast::Literal;
+
+fn main() {
+    let _x = Literal::I64(123);
+    println!("OK");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_example() {
+        assert!(true);
+    }
+}

--- a/src/bin/cvm-compile.rs
+++ b/src/bin/cvm-compile.rs
@@ -203,10 +203,10 @@ fn input_signals_info(
 /// of self and all its children
 fn create_component(
     templates: &[ast::Template], template_id: usize,
-    signal_start: usize) -> (Component, usize) {
+    signals_start: usize) -> (Component, usize) {
 
     let t = &templates[template_id];
-    let mut next_signal_start = signal_start + t.signals_num;
+    let mut next_signal_start = signals_start + t.signals_num;
     let mut components = Vec::with_capacity(t.components.len());
     for cmp_tmpl_id in t.components.iter() {
         components.push(match cmp_tmpl_id {
@@ -221,12 +221,12 @@ fn create_component(
     }
     (
         Component {
-            signals_start: signal_start,
-            template_id: template_id,
-            omponents: components,
+            signals_start,
+            template_id,
+            components,
             number_of_inputs: t.outputs.len(),
         },
-        next_signal_start - signal_start
+        next_signal_start - signals_start
     )
 }
 
@@ -744,50 +744,50 @@ mod tests {
         assert_eq!(component_tree.signals_start, 1);
         assert_eq!(component_tree.template_id, 6);
         assert_eq!(component_tree.number_of_inputs, 1);
-        assert_eq!(component_tree.omponents.len(), 2);
+        assert_eq!(component_tree.components.len(), 2);
 
         // Verify the first child component (Middle1)
-        let middle1 = component_tree.omponents[0].as_ref().unwrap();
+        let middle1 = component_tree.components[0].as_ref().unwrap();
         assert_eq!(middle1.signals_start, 6); // 1 (start) + 5 (signals_num of root)
         assert_eq!(middle1.template_id, 4);
         assert_eq!(middle1.number_of_inputs, 1);
-        assert_eq!(middle1.omponents.len(), 2);
+        assert_eq!(middle1.components.len(), 2);
 
         // Verify the second child component (Middle2)
-        let middle2 = component_tree.omponents[1].as_ref().unwrap();
+        let middle2 = component_tree.components[1].as_ref().unwrap();
         assert_eq!(middle2.signals_start, 16); // 6 (start of middle1) + 4 (signals_num of middle1) + 3 (signals_num of leaf1) + 3 (signals_num of leaf2)
         assert_eq!(middle2.template_id, 5);
         assert_eq!(middle2.number_of_inputs, 1);
-        assert_eq!(middle2.omponents.len(), 3);
+        assert_eq!(middle2.components.len(), 3);
 
         // Verify Middle2 has a None component
-        assert!(middle2.omponents[1].is_none());
+        assert!(middle2.components[1].is_none());
 
         // Verify the leaf components of Middle1
-        let leaf1 = middle1.omponents[0].as_ref().unwrap();
+        let leaf1 = middle1.components[0].as_ref().unwrap();
         assert_eq!(leaf1.signals_start, 10); // 6 (start of middle1) + 4 (signals_num of middle1)
         assert_eq!(leaf1.template_id, 0);
         assert_eq!(leaf1.number_of_inputs, 1);
-        assert_eq!(leaf1.omponents.len(), 0);
+        assert_eq!(leaf1.components.len(), 0);
 
-        let leaf2 = middle1.omponents[1].as_ref().unwrap();
+        let leaf2 = middle1.components[1].as_ref().unwrap();
         assert_eq!(leaf2.signals_start, 13); // 10 (start of leaf1) + 3 (signals_num of leaf1)
         assert_eq!(leaf2.template_id, 1);
         assert_eq!(leaf2.number_of_inputs, 1);
-        assert_eq!(leaf2.omponents.len(), 0);
+        assert_eq!(leaf2.components.len(), 0);
 
         // Verify the leaf components of Middle2
-        let leaf3 = middle2.omponents[0].as_ref().unwrap();
+        let leaf3 = middle2.components[0].as_ref().unwrap();
         assert_eq!(leaf3.signals_start, 20); // 16 (start of middle2) + 4 (signals_num of middle2)
         assert_eq!(leaf3.template_id, 2);
         assert_eq!(leaf3.number_of_inputs, 1);
-        assert_eq!(leaf3.omponents.len(), 0);
+        assert_eq!(leaf3.components.len(), 0);
 
-        let leaf4 = middle2.omponents[2].as_ref().unwrap();
+        let leaf4 = middle2.components[2].as_ref().unwrap();
         assert_eq!(leaf4.signals_start, 23); // 20 (start of leaf3) + 3 (signals_num of leaf3)
         assert_eq!(leaf4.template_id, 3);
         assert_eq!(leaf4.number_of_inputs, 1);
-        assert_eq!(leaf4.omponents.len(), 0);
+        assert_eq!(leaf4.components.len(), 0);
     }
 
     #[test]

--- a/src/bin/cvm-compile.rs
+++ b/src/bin/cvm-compile.rs
@@ -229,9 +229,7 @@ fn visit_inputs_json<F: FieldOperations>(
                 ff.parse_str(&n.to_string())?
             } else {
                 return Err(Box::new(RuntimeError::InvalidSignalsJson(
-                    format!(
-                        "invalid number at path {}: {}",
-                        prefix, n.to_string()))));
+                    format!("invalid number at path {}: {}", prefix, n))));
             };
             records.insert(prefix.to_string(), v);
         },
@@ -480,7 +478,7 @@ where
 
     let mut ctx = TemplateCompilationContext::new();
     for i in &t.body {
-        instruction::<T>(&mut ctx, &i);
+        instruction::<T>(&mut ctx, i);
     }
 
     vm2::Template {

--- a/src/bin/cvm-compile.rs
+++ b/src/bin/cvm-compile.rs
@@ -243,9 +243,7 @@ fn calculate_witness<T: FieldOps>(
     let mut signals = init_signals(
         &want_wtns.inputs_file, circuit.signals_num, &circuit.field,
         &circuit.input_signals_info)?;
-    execute(
-        &circuit.templates, &mut signals, circuit.main_template_id,
-        &circuit.field)?;
+    execute(&circuit.templates, &mut signals, &circuit.field, component_tree)?;
     let wtns_data = witness(
         &signals, &circuit.witness, circuit.field.prime)?;
 

--- a/src/bin/cvm-compile.rs
+++ b/src/bin/cvm-compile.rs
@@ -714,7 +714,7 @@ mod tests {
 
     #[test]
     fn test_example() {
-        assert!(true);
+        // Placeholder test
     }
 
     #[test]
@@ -883,7 +883,7 @@ mod tests {
         };
         let ff = Field::new(bn254_prime);
         let vm_tmpl = compile_template(&ast_tmpl, &ff).unwrap();
-        disassemble::<U254>(&vec![vm_tmpl]);
+        disassemble::<U254>(&[vm_tmpl]);
     }
 
     #[test]
@@ -897,7 +897,7 @@ mod tests {
   "b": false,
   "c": 100500
 }"#;
-        let result = parse_signals_json(i.as_bytes(), &&ff).unwrap();
+        let result = parse_signals_json(i.as_bytes(), &ff).unwrap();
         let mut want: HashMap<String, U254> = HashMap::new();
         want.insert("main.a".to_string(), U254::from_str("1").unwrap());
         want.insert("main.b".to_string(), U254::from_str("0").unwrap());
@@ -906,28 +906,28 @@ mod tests {
 
         // embedded objects
         let i = r#"{ "a": { "b": true } }"#;
-        let result = parse_signals_json(i.as_bytes(), &&ff).unwrap();
+        let result = parse_signals_json(i.as_bytes(), &ff).unwrap();
         let mut want: HashMap<String, U254> = HashMap::new();
         want.insert("main.a.b".to_string(), U254::from_str("1").unwrap());
         assert_eq!(want, result);
 
         // null error
         let i = r#"{ "a": { "b": null } }"#;
-        let result = parse_signals_json(i.as_bytes(), &&ff);
+        let result = parse_signals_json(i.as_bytes(), &ff);
         let binding = result.unwrap_err();
         let err = binding.downcast_ref::<RuntimeError>().unwrap();
         assert!(matches!(err, RuntimeError::InvalidSignalsJson(x) if x == "unexpected null value at path main.a.b"));
 
         // Negative number
         let i = r#"{ "a": { "b": -4 } }"#;
-        let result = parse_signals_json(i.as_bytes(), &&ff).unwrap();
+        let result = parse_signals_json(i.as_bytes(), &ff).unwrap();
         let mut want: HashMap<String, U254> = HashMap::new();
         want.insert("main.a.b".to_string(), U254::from_str("21888242871839275222246405745257275088548364400416034343698204186575808495613").unwrap());
         assert_eq!(want, result);
 
         // Float number error
         let i = r#"{ "a": { "b": 8.3 } }"#;
-        let result = parse_signals_json(i.as_bytes(), &&ff);
+        let result = parse_signals_json(i.as_bytes(), &ff);
         let binding = result.unwrap_err();
         let err = binding.downcast_ref::<RuntimeError>().unwrap();
         let msg = err.to_string();
@@ -935,14 +935,14 @@ mod tests {
 
         // string
         let i = r#"{ "a": { "b": "8" } }"#;
-        let result = parse_signals_json(i.as_bytes(), &&ff).unwrap();
+        let result = parse_signals_json(i.as_bytes(), &ff).unwrap();
         let mut want: HashMap<String, U254> = HashMap::new();
         want.insert("main.a.b".to_string(), U254::from_str("8").unwrap());
         assert_eq!(want, result);
 
         // array
         let i = r#"{ "a": { "b": ["8", 2, 3] } }"#;
-        let result = parse_signals_json(i.as_bytes(), &&ff).unwrap();
+        let result = parse_signals_json(i.as_bytes(), &ff).unwrap();
         let mut want: HashMap<String, U254> = HashMap::new();
         want.insert("main.a.b[0]".to_string(), U254::from_str("8").unwrap());
         want.insert("main.a.b[1]".to_string(), U254::from_str("2").unwrap());
@@ -966,7 +966,7 @@ mod tests {
     ]
   }
 }"#;
-        let result = parse_signals_json(i.as_bytes(), &&ff).unwrap();
+        let result = parse_signals_json(i.as_bytes(), &ff).unwrap();
         let mut want: HashMap<String, U254> = HashMap::new();
         want.insert("main.a[0]".to_string(), U254::from_str("300").unwrap());
         want.insert("main.a[1]".to_string(), U254::from_str("3").unwrap());

--- a/src/bin/cvm-compile.rs
+++ b/src/bin/cvm-compile.rs
@@ -174,7 +174,7 @@ where
     match inst {
         ast::TemplateInstruction::Assignment(assignment) => {
             expression::<T>(ctx, &assignment.value);
-            ctx.code.push(OpCode::StoreVariable as u8);
+            ctx.code.push(OpCode::StoreVariableFf as u8);
             let var_idx = ctx.get_ff_variable_index(&assignment.dest);
             ctx.code.extend_from_slice(var_idx.to_le_bytes().as_slice());
         }

--- a/src/bin/cvm-compile.rs
+++ b/src/bin/cvm-compile.rs
@@ -265,6 +265,13 @@ fn init_signals<F: FieldOperations>(
     for (path, value) in input_signals.iter() {
         match input_signals_info.get(path) {
             None => {
+                if path.ends_with("[0]") {
+                    let path = path.trim_end_matches("[0]");
+                    if let Some(signal_idx) = input_signals_info.get(path) {
+                        signals[*signal_idx] = Some(*value);
+                        continue;
+                    }
+                }
                 return Err(Box::new(
                     RuntimeError::InvalidSignalsJson(
                         format!("signal {} is not found in SYM file", path))))

--- a/src/bin/cvm-compile.rs
+++ b/src/bin/cvm-compile.rs
@@ -1,10 +1,61 @@
-
-use circom_witnesscalc::vm::ComponentTmpl;
+use std::env;
 use circom_witnesscalc::ast::Literal;
 
+struct Args {
+    cvm_file: String,
+    output_file: String,
+}
+
+
+fn parse_args() -> Args {
+    let mut cvm_file: Option<String> = None;
+    let mut output_file: Option<String> = None;
+
+    let args: Vec<String> = env::args().collect();
+
+    let usage = |err_msg: &str| {
+        if !err_msg.is_empty() {
+            eprintln!("ERROR:");
+            eprintln!("    {}", err_msg);
+            eprintln!();
+        }
+        eprintln!("USAGE:");
+        eprintln!("    {} <cvm_file> <output_path> [OPTIONS]", args[0]);
+        eprintln!();
+        eprintln!("ARGUMENTS:");
+        eprintln!("    <cvm_file>    Path to the CVM file with compiled circuit");
+        eprintln!("    <output_path> File where the witness will be saved");
+        eprintln!();
+        eprintln!("OPTIONS:");
+        eprintln!("    -h | --help                Display this help message");
+        let exit_code = if !err_msg.is_empty() { 1i32 } else { 0i32 };
+        std::process::exit(exit_code);
+    };
+
+    let mut i = 1;
+    while i < args.len() {
+        if args[i] == "--help" || args[i] == "-h" {
+            usage("");
+        } else if args[i].starts_with("-") {
+            usage(format!("Unknown option: {}", args[i]).as_str());
+        } else if cvm_file.is_none() {
+            cvm_file = Some(args[i].clone());
+        } else if output_file.is_none() {
+            output_file = Some(args[i].clone());
+        }
+        i += 1;
+    }
+    Args {
+        cvm_file: cvm_file.unwrap_or_else(|| { usage("missing CVM file"); String::new() }),
+        output_file: output_file.unwrap_or_else(|| { usage("missing output file"); String::new() }),
+    }
+}
+
 fn main() {
+    let args = parse_args();
+
     let _x = Literal::I64(123);
-    println!("OK");
+    println!("OK {}", args.cvm_file);
 }
 
 #[cfg(test)]

--- a/src/bin/cvm-compile.rs
+++ b/src/bin/cvm-compile.rs
@@ -460,6 +460,11 @@ where
             operand_ff::<T>(ctx, lhs);
             ctx.code.push(OpCode::OpAdd as u8);
         },
+        ast::Expr::FfNeq(lhs, rhs) => {
+            operand_ff::<T>(ctx, rhs);
+            operand_ff::<T>(ctx, lhs);
+            ctx.code.push(OpCode::OpNeq as u8);
+        },
     }
 }
 

--- a/src/bin/cvm-compile.rs
+++ b/src/bin/cvm-compile.rs
@@ -493,7 +493,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use num_traits::Zero;
     use circom_witnesscalc::ast::{Assignment, Expr, FfOperand, I64Operand, TemplateInstruction};
     use circom_witnesscalc::field::{bn254_prime, Field};
     use super::*;
@@ -643,16 +642,5 @@ mod tests {
         want.insert("main.v.v[1].end.x".to_string(), U254::from_str("10").unwrap());
         want.insert("main.v.v[1].end.y".to_string(), U254::from_str("11").unwrap());
         assert_eq!(want, result);
-    }
-
-    #[test]
-    fn negative() {
-        let i: i64 = -1;
-        // let x = <U254 as FieldOps>::from_str("-1").unwrap();
-        let x = <U254 as Zero>::zero();
-        let bn254 = U254::from_str_radix("21888242871839275222246405745257275088548364400416034343698204186575808495617", 10).unwrap();
-        let f = Field::new(bn254);
-        // <f as FieldOperations>::
-        // println!("{:?}", f);
     }
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -374,6 +374,7 @@ pub trait FieldOperations {
     fn neg(&self, lhs: Self::Type) -> Self::Type;
 }
 
+#[derive(Clone)]
 pub struct Field<T> where T: FieldOps {
     pub prime: T,
     halfPrime: T,

--- a/src/field.rs
+++ b/src/field.rs
@@ -454,6 +454,46 @@ impl<T: FieldOps> FieldOperations for &Field<T> {
         }
     }
 
+    fn op_uno(&self, op: UnoOperation, a: T) -> T {
+        match op {
+            UnoOperation::Neg => self.neg(a),
+            UnoOperation::Id => a,
+            UnoOperation::Lnot => self.lnot(a),
+            UnoOperation::Bnot => self.bnot(a),
+        }
+    }
+
+    fn op_duo(&self, op: Operation, a: T, b: T) -> T {
+        match op {
+            Operation::Mul => self.mul(a, b),
+            Operation::Div => self.div(a, b),
+            Operation::Add => self.add(a, b),
+            Operation::Sub => self.sub(a, b),
+            Operation::Pow => self.pow(a, b),
+            Operation::Idiv => self.idiv(a, b),
+            Operation::Mod => self.modulo(a, b),
+            Operation::Eq => self.eq(a, b),
+            Operation::Neq => self.neq(a, b),
+            Operation::Lt => self.lt(a, b),
+            Operation::Gt => self.gt(a, b),
+            Operation::Leq => self.lte(a, b),
+            Operation::Geq => self.gte(a, b),
+            Operation::Land => self.land(a, b),
+            Operation::Lor => self.lor(a, b),
+            Operation::Shl => self.shl(a, b),
+            Operation::Shr => self.shr(a, b),
+            Operation::Bor => self.bor(a, b),
+            Operation::Band => self.band(a, b),
+            Operation::Bxor => self.bxor(a, b),
+        }
+    }
+
+    fn op_tres(&self, op: TresOperation, a: T, b: T, c: T) -> T {
+        match op {
+            TresOperation::TernCond => if a.is_zero() { c } else { b }
+        }
+    }
+
     #[inline]
     fn mul(&self, lhs: Self::Type, rhs: Self::Type) -> Self::Type {
         lhs.mul_mod(rhs, self.prime)
@@ -573,6 +613,15 @@ impl<T: FieldOps> FieldOperations for &Field<T> {
     }
 
     #[inline]
+    fn lnot(&self, lhs: Self::Type) -> Self::Type {
+        if lhs.is_zero() {
+            T::one()
+        } else {
+            T::zero()
+        }
+    }
+
+    #[inline]
     fn shl(&self, lhs: Self::Type, rhs: Self::Type) -> Self::Type {
         match self.to_isize(rhs) {
             Some(r) => {
@@ -636,16 +685,6 @@ impl<T: FieldOps> FieldOperations for &Field<T> {
             r
         }
     }
-
-    #[inline]
-    fn idiv(&self, lhs: Self::Type, rhs: Self::Type) -> Self::Type {
-        if rhs.is_zero() {
-            T::zero()
-        } else {
-            lhs / rhs
-        }
-    }
-
     #[inline]
     fn bnot(&self, lhs: Self::Type) -> Self::Type {
         let lhs = lhs.not();
@@ -658,59 +697,20 @@ impl<T: FieldOps> FieldOperations for &Field<T> {
     }
 
     #[inline]
+    fn idiv(&self, lhs: Self::Type, rhs: Self::Type) -> Self::Type {
+        if rhs.is_zero() {
+            T::zero()
+        } else {
+            lhs / rhs
+        }
+    }
+
+    #[inline]
     fn neg(&self, lhs: Self::Type) -> Self::Type {
         if lhs.is_zero() {
             T::zero()
         } else {
             self.prime - lhs
-        }
-    }
-
-    #[inline]
-    fn lnot(&self, lhs: Self::Type) -> Self::Type {
-        if lhs.is_zero() {
-            T::one()
-        } else {
-            T::zero()
-        }
-    }
-    fn op_uno(&self, op: UnoOperation, a: T) -> T {
-        match op {
-            UnoOperation::Neg => self.neg(a),
-            UnoOperation::Id => a,
-            UnoOperation::Lnot => self.lnot(a),
-            UnoOperation::Bnot => self.bnot(a),
-        }
-    }
-
-    fn op_duo(&self, op: Operation, a: T, b: T) -> T {
-        match op {
-            Operation::Mul => self.mul(a, b),
-            Operation::Div => self.div(a, b),
-            Operation::Add => self.add(a, b),
-            Operation::Sub => self.sub(a, b),
-            Operation::Pow => self.pow(a, b),
-            Operation::Idiv => self.idiv(a, b),
-            Operation::Mod => self.modulo(a, b),
-            Operation::Eq => self.eq(a, b),
-            Operation::Neq => self.neq(a, b),
-            Operation::Lt => self.lt(a, b),
-            Operation::Gt => self.gt(a, b),
-            Operation::Leq => self.lte(a, b),
-            Operation::Geq => self.gte(a, b),
-            Operation::Land => self.land(a, b),
-            Operation::Lor => self.lor(a, b),
-            Operation::Shl => self.shl(a, b),
-            Operation::Shr => self.shr(a, b),
-            Operation::Bor => self.bor(a, b),
-            Operation::Band => self.band(a, b),
-            Operation::Bxor => self.bxor(a, b),
-        }
-    }
-
-    fn op_tres(&self, op: TresOperation, a: T, b: T, c: T) -> T {
-        match op {
-            TresOperation::TernCond => if a.is_zero() { c } else { b }
         }
     }
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -170,6 +170,7 @@ impl TryFrom<usize> for U64 {
 
 impl FieldOps for U64 {
     const BITS: usize = 64;
+    const BYTES: usize = 8;
     const MAX: U64 = U64(u64::MAX);
 
     fn from_str(v: &str) -> Result<Self, Box<dyn std::error::Error>> {
@@ -264,6 +265,7 @@ pub type U254 = ruint::Uint<254, 4>;
 impl FieldOps for U254 {
 
     const BITS: usize = 254;
+    const BYTES: usize = 32;
     const MAX: U254 = U254::MAX;
 
     fn from_str(v: &str) -> Result<Self, Box<dyn std::error::Error>> {
@@ -318,6 +320,7 @@ pub trait FieldOps: Sized + Copy + Zero + One + PartialEq + Sub<Output = Self>
     + Eq + Hash + TryFrom<usize> + Display {
 
     const BITS: usize;
+    const BYTES: usize;
     const MAX: Self;
 
     fn from_str(v: &str) -> Result<Self, Box<dyn std::error::Error>>;

--- a/src/field.rs
+++ b/src/field.rs
@@ -7,7 +7,6 @@ use anyhow::anyhow;
 use ruint::{aliases::U256, uint};
 use ruint::aliases::U128;
 use num_traits::{Zero, One};
-use wtns_file::FieldElement;
 use crate::graph::{Operation, TresOperation, UnoOperation};
 
 pub const M: U256 =

--- a/src/field.rs
+++ b/src/field.rs
@@ -402,10 +402,7 @@ impl<T: FieldOps> Field<T> {
                 Err(_) => None,
             }
         } else {
-            match value.try_into() {
-                Ok(v) => Some(v),
-                Err(_) => None,
-            }
+            value.try_into().ok()
         }
     }
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -7,6 +7,7 @@ use anyhow::anyhow;
 use ruint::{aliases::U256, uint};
 use ruint::aliases::U128;
 use num_traits::{Zero, One};
+use wtns_file::FieldElement;
 use crate::graph::{Operation, TresOperation, UnoOperation};
 
 pub const M: U256 =

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -786,15 +786,15 @@ impl<T: FieldOps + 'static, NS: NodesStorage + 'static> NodesInterface for Nodes
             Node::Constant(c_idx) => {
                 let v = self.constants[c_idx];
                 let idx = self.const_node_idx_from_value(v);
-                return NodeIdx(idx);
+                NodeIdx(idx)
             },
             Node::UnoOp(op, a) => {
                 if let Some(Node::Constant(a_idx)) = self.nodes.get(a) {
                     let v = (&self.ff).op_uno(op, self.constants[a_idx]);
                     let idx = self.const_node_idx_from_value(v);
-                    return NodeIdx(idx);
+                    NodeIdx(idx)
                 } else {
-                    return self.push_noopt(n);
+                    self.push_noopt(n)
                 }
             }
             Node::Op(op, a, b) => {
@@ -806,9 +806,9 @@ impl<T: FieldOps + 'static, NS: NodesStorage + 'static> NodesInterface for Nodes
 
                     let v = (&self.ff).op_duo(op, self.constants[a_idx], self.constants[b_idx]);
                     let idx = self.const_node_idx_from_value(v);
-                    return NodeIdx(idx);
+                    NodeIdx(idx)
                 } else {
-                    return self.push_noopt(n);
+                    self.push_noopt(n)
                 }
             }
             Node::TresOp(op, a, b, c) => {
@@ -824,13 +824,13 @@ impl<T: FieldOps + 'static, NS: NodesStorage + 'static> NodesInterface for Nodes
                         op, self.constants[a_idx], self.constants[b_idx],
                         self.constants[c_idx]);
                     let idx = self.const_node_idx_from_value(v);
-                    return NodeIdx(idx);
+                    NodeIdx(idx)
                 } else {
-                    return self.push_noopt(n);
+                    self.push_noopt(n)
                 }
             }
             Node::Input(_) => {
-                return self.push_noopt(n);
+                self.push_noopt(n)
             },
         }
     }
@@ -1248,7 +1248,7 @@ pub fn tree_shake<T: FieldOps + 'static, NS: NodesStorage + 'static>(
 }
 
 fn rnd<T: FieldOps>(ff: &Field<T>, rng: &mut ThreadRng) -> T {
-    let x: usize = (T::BITS + 7) / 8;
+    let x = T::BITS.div_ceil(8);
     let mut bs = vec![0u8; x];
     rng.fill_bytes(&mut bs);
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1692,7 +1692,7 @@ mod tests {
         assert_eq!(nodes.ln, 0);
         nodes.push(Node::TresOp(TresOperation::TernCond, 1, 2, 3));
         assert_eq!(nodes.cap, 2 * Node::SIZE);
-        assert_eq!(nodes.ln, 1 * Node::SIZE);
+        assert_eq!(nodes.ln, Node::SIZE);
 
         nodes.push(Node::TresOp(TresOperation::TernCond, 1, 2, 3));
         assert_eq!(nodes.cap, 2 * Node::SIZE);
@@ -1711,7 +1711,7 @@ mod tests {
         assert_eq!(nodes.ln, 0);
         nodes.push(Node::TresOp(TresOperation::TernCond, 1, 2, 3));
         assert_eq!(nodes.cap, 2 * Node::SIZE);
-        assert_eq!(nodes.ln, 1 * Node::SIZE);
+        assert_eq!(nodes.ln, Node::SIZE);
 
         nodes.push(Node::TresOp(TresOperation::TernCond, 1, 2, 3));
         assert_eq!(nodes.cap, 2 * Node::SIZE);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -651,22 +651,7 @@ impl<T: FieldOps + 'static, NS: NodesStorage + 'static> Nodes<T, NS> {
         match me {
             Node::Unknown => panic!("Unknown node"),
             Node::Constant(const_idx) => Ok(self.constants[const_idx]),
-            Node::UnoOp(op, a) => {
-                Ok((&self.ff).op_uno(op,
-                    self.to_const_recursive(NodeIdx(a))?))
-            }
-            Node::Op(op, a, b) => {
-                Ok((&self.ff).op_duo(op,
-                    self.to_const_recursive(NodeIdx(a))?,
-                    self.to_const_recursive(NodeIdx(b))?))
-            }
-            Node::TresOp(op, a, b, c) => {
-                Ok((&self.ff).op_tres(op,
-                    self.to_const_recursive(NodeIdx(a))?,
-                    self.to_const_recursive(NodeIdx(b))?,
-                    self.to_const_recursive(NodeIdx(c))?))
-            }
-            Node::Input(_) => Err(NodeConstErr::InputSignal),
+            _ => { Err(NodeConstErr::InputSignal) }
         }
     }
 
@@ -691,58 +676,6 @@ impl<T: FieldOps + 'static, NS: NodesStorage + 'static> Nodes<T, NS> {
             if let Node::Constant(c_idx) = node {
                 self.constants_idx.insert(self.constants[c_idx], i);
             }
-        }
-    }
-
-    // try to return a constant node if operands are constant, otherwise return
-    // the unmodified node
-    fn try_into_constant(&mut self, n: &Node) -> Result<Node, NodeConstErr> {
-        match n {
-            Node::Unknown => panic!("Unknown node"),
-            Node::Constant(c_idx) => Ok(Node::Constant(*c_idx)),
-            Node::UnoOp(op, a) => {
-                if let Some(Node::Constant(a_idx)) = self.nodes.get(*a) {
-                    let v = (&self.ff).op_uno(*op, self.constants[a_idx]);
-                    let idx = self.const_node_idx_from_value(v);
-                    Ok(self.nodes.get(idx).unwrap())
-                } else {
-                    Err(NodeConstErr::NotConst)
-                }
-            }
-            Node::Op(op, a, b) => {
-                if let (
-                    Some(Node::Constant(a_idx)),
-                    Some(Node::Constant(b_idx))) = (
-                    self.nodes.get(*a),
-                    self.nodes.get(*b)) {
-
-                    let v = (&self.ff).op_duo(*op, self.constants[a_idx], self.constants[b_idx]);
-                    let idx = self.const_node_idx_from_value(v);
-                    Ok(self.nodes.get(idx).unwrap())
-                } else {
-                    Err(NodeConstErr::NotConst)
-                }
-            }
-            Node::TresOp(op, a, b, c) => {
-                if let (
-                    Some(Node::Constant(a_idx)),
-                    Some(Node::Constant(b_idx)),
-                    Some(Node::Constant(c_idx))) = (
-                    self.nodes.get(*a),
-                    self.nodes.get(*b),
-                    self.nodes.get(*c)) {
-
-                    let v = (&self.ff).op_tres(
-                        *op, self.constants[a_idx], self.constants[b_idx],
-                        self.constants[c_idx]);
-                    let const_node_idx =
-                        self.const_node_idx_from_value(v);
-                    Ok(self.nodes.get(const_node_idx).unwrap())
-                } else {
-                    Err(NodeConstErr::NotConst)
-                }
-            }
-            Node::Input(_) => Err(NodeConstErr::InputSignal),
         }
     }
 
@@ -848,8 +781,58 @@ impl<T: FieldOps + 'static, NS: NodesStorage + 'static> NodesInterface for Nodes
     }
 
     fn push(&mut self, n: Node) -> NodeIdx {
-        let n = self.try_into_constant(&n).unwrap_or(n);
-        self.push_noopt(n)
+        match n {
+            Node::Unknown => panic!("Unknown node"),
+            Node::Constant(c_idx) => {
+                let v = self.constants[c_idx];
+                let idx = self.const_node_idx_from_value(v);
+                return NodeIdx(idx);
+            },
+            Node::UnoOp(op, a) => {
+                if let Some(Node::Constant(a_idx)) = self.nodes.get(a) {
+                    let v = (&self.ff).op_uno(op, self.constants[a_idx]);
+                    let idx = self.const_node_idx_from_value(v);
+                    return NodeIdx(idx);
+                } else {
+                    return self.push_noopt(n);
+                }
+            }
+            Node::Op(op, a, b) => {
+                if let (
+                    Some(Node::Constant(a_idx)),
+                    Some(Node::Constant(b_idx))) = (
+                    self.nodes.get(a),
+                    self.nodes.get(b)) {
+
+                    let v = (&self.ff).op_duo(op, self.constants[a_idx], self.constants[b_idx]);
+                    let idx = self.const_node_idx_from_value(v);
+                    return NodeIdx(idx);
+                } else {
+                    return self.push_noopt(n);
+                }
+            }
+            Node::TresOp(op, a, b, c) => {
+                if let (
+                    Some(Node::Constant(a_idx)),
+                    Some(Node::Constant(b_idx)),
+                    Some(Node::Constant(c_idx))) = (
+                    self.nodes.get(a),
+                    self.nodes.get(b),
+                    self.nodes.get(c)) {
+
+                    let v = (&self.ff).op_tres(
+                        op, self.constants[a_idx], self.constants[b_idx],
+                        self.constants[c_idx]);
+                    let idx = self.const_node_idx_from_value(v);
+                    return NodeIdx(idx);
+                } else {
+                    return self.push_noopt(n);
+                }
+            }
+            Node::Input(_) => {
+                return self.push_noopt(n);
+            },
+        }
     }
 
     fn get_inputs_size(&self) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ pub mod field;
 pub mod graph;
 pub mod storage;
 pub mod vm;
+pub mod ast;
+
+mod parser;
 
 use std::collections::HashMap;
 use std::ffi::{c_char, c_int, c_void, CStr};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ fn wtns_from_witness(witness: Vec<FieldElement<32>>) -> Vec<u8> {
     buf
 }
 
-fn wtns_from_witness2<const FS: usize, T: FieldOps>(
+pub fn wtns_from_witness2<const FS: usize, T: FieldOps>(
     witness: Vec<FieldElement<FS>>, prime: T) -> Vec<u8> {
 
     let mut buf = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,10 @@ pub mod field;
 pub mod graph;
 pub mod storage;
 pub mod vm;
+pub mod vm2;
 pub mod ast;
 
-mod parser;
+pub mod parser;
 
 use std::collections::HashMap;
 use std::ffi::{c_char, c_int, c_void, CStr};

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -242,7 +242,7 @@ fn parse_statement(input: &mut &str) -> ModalResult<Statement> {
 
 fn parse_expression(input: &mut &str) -> ModalResult<Expr> {
     let x = dispatch! {parse_operator_name;
-        "get_signal" => preceded(space1, parse_i64_operand).map(|op| Expr::GetSignal(op)),
+        "get_signal" => preceded(space1, parse_i64_operand).map(Expr::GetSignal),
         "ff.mul" => (preceded(space1, parse_ff_operand), preceded(space1, parse_ff_operand))
             .map(|(op1, op2)| Expr::FfMul(op1, op2)),
         "ff.add" => (preceded(space1, parse_ff_operand), preceded(space1, parse_ff_operand))
@@ -287,7 +287,7 @@ fn parse_ff_signal(i: &mut &str) -> ModalResult<Signal> {
         return Ok(Signal::Ff(vec![]));
     }
 
-    assert!(sp.len() > 0);
+    assert!(!sp.is_empty());
 
     let dims: Vec<usize> = repeat(
         dims_num..=dims_num, terminated(parse_usize, space0))
@@ -308,7 +308,7 @@ fn parse_opt_usize(i: &mut &str) -> ModalResult<Option<usize>> {
             }
         }
         None => {
-            let val = usize::from_str_radix(digs, 10)
+            let val = digs.parse()
                 .map_err(|_| ErrMode::Cut(ContextError::from_input(i)))?;
             Ok(Some(val))
         }
@@ -333,7 +333,7 @@ fn parse_bus_signal(i: &mut &str) -> ModalResult<Signal> {
         return Ok(Signal::Bus(bus_name, vec![]));
     }
 
-    assert!(sp.len() > 0);
+    assert!(!sp.is_empty());
 
     let dims: Vec<usize> = repeat(
         dims_num..=dims_num, terminated(parse_usize, space0))

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,906 @@
+use num_bigint::BigUint;
+use winnow::ascii::{digit1, space0, space1, line_ending, alpha1};
+use winnow::error::{AddContext, ContextError, ErrMode, ParserError, StrContext, StrContextValue};
+use winnow::{ModalResult};
+use winnow::combinator::{alt, preceded, repeat, terminated, seq, dispatch, fail, opt, cut_err, trace, eof, delimited};
+use winnow::Parser;
+use winnow::token::{literal, take_till, take_while};
+use crate::ast::{Assignment, ComponentsMode, Expr, FfOperand, I64Operand, Signal, Statement, Template, TemplateInstruction, AST};
+
+fn parse_prime(input: &mut &str) -> ModalResult<BigUint> {
+    let (bi, ): (BigUint, ) = seq!(
+        _: ("%%prime", space1),
+        cut_err(digit1.parse_to()
+            .context(StrContext::Label("prime"))
+            .context(StrContext::Expected(StrContextValue::Description("valid prime value")))),
+        _: (
+            space0,
+            opt(parse_eol_comment),
+            cut_err(line_ending).context(StrContext::Expected(StrContextValue::CharLiteral('\n')))
+        )
+    ).parse_next(input)?;
+    Ok(bi)
+}
+
+fn parse_signals_num(input: &mut &str) -> ModalResult<usize> {
+    let (i, ): (usize, ) = seq!(
+        _: ("%%signals", space1),
+        cut_err(parse_usize),
+        _: (
+            space0,
+            opt(parse_eol_comment),
+            cut_err(line_ending).context(StrContext::Expected(StrContextValue::CharLiteral('\n')))
+        )
+    ).parse_next(input)?;
+    Ok(i)
+}
+
+fn parse_components_heap(input: &mut &str) -> ModalResult<usize> {
+    let (i, ): (usize, ) = seq!(
+        _: ("%%components_heap", space1),
+        cut_err(parse_usize),
+        _: (
+            space0,
+            opt(parse_eol_comment),
+            cut_err(line_ending).context(StrContext::Expected(StrContextValue::CharLiteral('\n')))
+        )
+    ).parse_next(input)?;
+    Ok(i)
+}
+
+#[derive(Debug)]
+enum Error {
+    NotValidComponentsMode,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::NotValidComponentsMode => write!(f, "Invalid components mode"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+fn parse_components_creation_mode(input: &mut &str) -> ModalResult<ComponentsMode> {
+    let (s, ): (ComponentsMode, ) = seq!(
+        _: ("%%components", space1),
+        cut_err(
+            alpha1.try_map(|s| match s {
+                "implicit" => Ok(ComponentsMode::Implicit),
+                "explicit" => Ok(ComponentsMode::Explicit),
+                _ => Err(Error::NotValidComponentsMode),
+            })
+            .context(StrContext::Label("components mode"))
+        ),
+        _: (
+            space0,
+            opt(parse_eol_comment),
+            cut_err(line_ending).context(StrContext::Expected(StrContextValue::CharLiteral('\n')))
+        )
+    ).parse_next(input)?;
+    Ok(s)
+}
+
+fn parse_start_template(input: &mut &str) -> ModalResult<String> {
+    let (s, ): (&str, ) = seq!(
+        _: ("%%start", space1),
+        cut_err(parse_variable_name),
+        _: (
+            space0,
+            opt(parse_eol_comment),
+            cut_err(line_ending).context(StrContext::Expected(StrContextValue::CharLiteral('\n')))
+        )
+    ).parse_next(input)?;
+    Ok(s.to_owned())
+}
+
+fn parse_witness_list(input: &mut &str) -> ModalResult<Vec<usize>> {
+    let (s, ): (Vec<usize>, ) = seq!(
+        _: ("%%witness", space1),
+        cut_err(parse_vec_usize),
+        _: (
+            space0,
+            opt(parse_eol_comment),
+            cut_err(line_ending).context(StrContext::Expected(StrContextValue::CharLiteral('\n')))
+        )
+    ).parse_next(input)?;
+    Ok(s)
+}
+
+fn parse_i64_literal(input: &mut &str) -> ModalResult<i64> {
+    preceded(
+        literal("i64."),
+        cut_err(digit1.parse_to()
+            .context(StrContext::Label("i64 literal")))
+            .context(StrContext::Expected(StrContextValue::Description("valid i64 value"))),)
+        .parse_next(input)
+}
+
+fn parse_ff_literal(input: &mut &str) -> ModalResult<BigUint> {
+    preceded(
+        literal("ff."),
+        cut_err(digit1.parse_to()
+            .context(StrContext::Label("ff literal")))
+            .context(StrContext::Expected(StrContextValue::Description("valid ff value"))),)
+        .parse_next(input)
+}
+
+fn parse_i64_operand(input: &mut &str) -> ModalResult<I64Operand> {
+    if let Some(x) = opt(parse_i64_literal).parse_next(input)? {
+        Ok(I64Operand::Literal(x))
+    } else if let Some(x) = opt(parse_variable_name).parse_next(input)? {
+        Ok(I64Operand::Variable(x.to_string()))
+    } else {
+        fail.parse_next(input)?
+    }
+}
+
+fn parse_ff_operand(input: &mut &str) -> ModalResult<FfOperand> {
+    if let Some(x) = opt(parse_ff_literal).parse_next(input)? {
+        Ok(FfOperand::Literal(x))
+    } else if let Some(x) = opt(parse_variable_name).parse_next(input)? {
+        Ok(FfOperand::Variable(x.to_string()))
+    } else {
+        fail.parse_next(input)?
+    }
+}
+
+fn parse_variable_name<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+    trace(
+        "parse_variable_name",
+        |i: &mut _| {
+            let var_name = take_while(1..,
+                       |c: char| c.is_alphabetic() || c.is_numeric() || c == '_')
+                .verify(|v: &str| {
+                    let c = v.chars().next().unwrap();
+                    c.is_alphabetic() || c == '_'
+                })
+                .parse_next(i)?;
+            Ok(var_name)
+        }
+    ).parse_next(input)
+}
+
+fn parse_operator_name<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+    let var_name = take_while(1..,
+               |c: char| c.is_alphabetic() || c.is_numeric() || c == '_' || c == '.')
+        .parse_next(input)?;
+    Ok(var_name)
+}
+
+fn parse_line_end(i: &mut &str) -> ModalResult<()> {
+    alt((winnow::ascii::crlf, literal("\n"), eof)).void().parse_next(i)
+}
+
+fn parse_empty_line(input: &mut &str) -> ModalResult<()> {
+    trace(
+        "parse_empty_line",
+        |i: &mut _| {
+            (
+                space0,
+                opt(parse_eol_comment),
+                parse_line_end
+            ).map(|_| ()).parse_next(i)
+        }
+    ).parse_next(input)
+}
+
+fn parse_template_body(input: &mut &str) -> ModalResult<Vec<TemplateInstruction>> {
+    let mut instructions = Vec::new();
+    'outer: while !input.is_empty() {
+        let inst = alt((
+            parse_assignment.map(|x| Some(TemplateInstruction::Assignment(x))),
+            parse_statement.map(|x| Some(TemplateInstruction::Statement(x))),
+            parse_empty_line.map(|_| None),
+        )).parse_next(input);
+        match inst {
+            Ok(Some(inst)) => { instructions.push(inst); }
+            Ok(None) => (),
+            Err(err) => {
+                match err {
+                    ErrMode::Cut(_) => { return Err(err); }
+                    _ => { break 'outer; }
+                }
+            }
+        }
+    }
+    if instructions.is_empty() {
+        return Err(ErrMode::Cut(ContextError::from_input(input)));
+    }
+    Ok(instructions)
+}
+
+fn parse_assignment(input: &mut &str) -> ModalResult<Assignment> {
+    let (var_name, _, _, _, expr, _, _, _) = seq!(
+        parse_variable_name,
+        space0, literal("="), space0,
+        parse_expression,
+        space0,
+        opt(parse_eol_comment),
+        parse_line_end)
+        .parse_next(input)?;
+    Ok(Assignment{
+        dest: var_name.to_string(),
+        value: expr,
+    })
+}
+
+fn parse_statement(input: &mut &str) -> ModalResult<Statement> {
+    let s = dispatch! {parse_operator_name;
+        "set_signal" => (preceded(space1, parse_i64_operand), preceded(space1, parse_ff_operand))
+            .map(|(op1, op2)| Statement::SetSignal{ idx: op1, value: op2 }),
+        _ => fail::<_, Statement, _>,
+    }
+        .parse_next(input)?;
+
+    (space0, opt(parse_eol_comment), parse_line_end).parse_next(input)?;
+
+    Ok(s)
+}
+
+fn parse_expression(input: &mut &str) -> ModalResult<Expr> {
+    let x = dispatch! {parse_operator_name;
+        "get_signal" => preceded(space1, parse_i64_operand).map(|op| Expr::GetSignal(op)),
+        "ff.mul" => (preceded(space1, parse_ff_operand), preceded(space1, parse_ff_operand))
+            .map(|(op1, op2)| Expr::FfMul(op1, op2)),
+        "ff.add" => (preceded(space1, parse_ff_operand), preceded(space1, parse_ff_operand))
+            .map(|(op1, op2)| Expr::FfAdd(op1, op2)),
+        // "get_signal" => {
+        //     Ok(Expr::GetSignal(I64Operand::Literal(0)))
+        // },
+        // "get_signal" => {
+        //     // Parse the rest of the expression
+        //     let operand = i64_operand.parse_next(input)?;
+        //     Ok(Expr::GetSignal(operand))
+        // },
+        _ => fail::<_, Expr, _>,
+    }
+        .parse_next(input)?;
+        // "ff.add" => {
+        //     // Parse the rest of the expression
+        //     let operand1 = i64_operand.parse_next(input)?;
+        //     let operand2 = i64_operand.parse_next(input)?;
+        //     Ok(Expr::FfAdd(operand1, operand2))
+        // },
+    // println!("{}", x);
+    Ok(x)
+}
+
+fn parse_eol_comment(i: &mut &str) -> ModalResult<()>
+{
+    (";;", take_till(0.., ['\n', '\r']))
+        .void() // Output is thrown away.
+        .parse_next(i)
+}
+
+fn parse_usize(i: &mut &str) -> ModalResult<usize> {
+    digit1.parse_to().context(StrContext::Label("usize")).parse_next(i)
+}
+
+fn parse_ff_signal(i: &mut &str) -> ModalResult<Signal> {
+
+    let (_, _, dims_num, sp) = (literal("ff"), space1, parse_usize, space0).parse_next(i)?;
+
+    if dims_num == 0 {
+        return Ok(Signal::Ff(vec![]));
+    }
+
+    assert!(sp.len() > 0);
+
+    let dims: Vec<usize> = repeat(
+        dims_num..=dims_num, terminated(parse_usize, space0))
+        .parse_next(i)?;
+
+    assert_eq!(dims.len(), dims_num);
+    Ok(Signal::Ff(dims))
+}
+
+fn parse_opt_usize(i: &mut &str) -> ModalResult<Option<usize>> {
+    let (sign, digs) = (opt('-'), digit1).parse_next(i)?;
+    match sign {
+        Some(_) => {
+            if digs == "1" {
+                Ok(None)
+            } else {
+                Err(ErrMode::Cut(ContextError::from_input(i)))
+            }
+        }
+        None => {
+            let val = usize::from_str_radix(digs, 10)
+                .map_err(|_| ErrMode::Cut(ContextError::from_input(i)))?;
+            Ok(Some(val))
+        }
+    }
+}
+
+fn parse_vec_opt_usize(input: &mut &str) -> ModalResult<Vec<Option<usize>>> {
+    repeat(0.., terminated(parse_opt_usize, space0))
+        .parse_next(input)
+}
+
+fn parse_vec_usize(input: &mut &str) -> ModalResult<Vec<usize>> {
+    repeat(0.., terminated(parse_usize, space0)).parse_next(input)
+}
+
+fn parse_bus_signal(i: &mut &str) -> ModalResult<Signal> {
+    let (_, bus_id, _, dims_num, sp) =
+        (literal("bus_"), digit1, space1, parse_usize, space0).parse_next(i)?;
+    let bus_name = format!("bus_{}", bus_id);
+
+    if dims_num == 0 {
+        return Ok(Signal::Bus(bus_name, vec![]));
+    }
+
+    assert!(sp.len() > 0);
+
+    let dims: Vec<usize> = repeat(
+        dims_num..=dims_num, terminated(parse_usize, space0))
+        .parse_next(i)?;
+
+    assert_eq!(dims.len(), dims_num);
+    Ok(Signal::Bus(bus_name, dims))
+}
+
+fn parse_signals(i: &mut &str) -> ModalResult<Vec<Signal>> {
+    delimited(
+        terminated('[', space0),
+        repeat(0.., alt((parse_ff_signal, parse_bus_signal))),
+        ']').parse_next(i)
+}
+
+fn parse_template(i: &mut &str) -> ModalResult<Template> {
+    seq!{Template{
+        _: (literal("%%template"), space1),
+        name: parse_variable_name.map(|s: &str| s.to_owned()),
+        _: space1,
+        outputs: parse_signals,
+        _: space0,
+        inputs: parse_signals,
+        _: (space0, '[', space0),
+        signals_num: parse_usize,
+        _: (space0, ']', space0, '[', space0),
+        components: parse_vec_opt_usize,
+        _: (space0, ']', space0, line_ending),
+        body: parse_template_body,
+    }}.parse_next(i)
+}
+
+fn parse_ast(i: &mut &str) -> ModalResult<AST> {
+    seq!{AST{
+        _: repeat(0.., parse_empty_line),
+        prime: parse_prime
+            .context(StrContext::Expected(StrContextValue::StringLiteral("%%prime"))),
+        _: repeat(0.., parse_empty_line),
+        signals: parse_signals_num
+            .context(StrContext::Expected(StrContextValue::StringLiteral("%%signals"))),
+        _: repeat(0.., parse_empty_line),
+        components_heap: parse_components_heap
+            .context(StrContext::Expected(StrContextValue::StringLiteral("%%components_heap"))),
+        _: repeat(0.., parse_empty_line),
+        start: parse_start_template
+            .context(StrContext::Expected(StrContextValue::StringLiteral("%%start"))),
+        _: repeat(0.., parse_empty_line),
+        components_mode: parse_components_creation_mode
+            .context(StrContext::Expected(StrContextValue::StringLiteral("%%components"))),
+        _: repeat(0.., parse_empty_line),
+        witness: parse_witness_list
+            .context(StrContext::Expected(StrContextValue::StringLiteral("%%witness"))),
+        _: repeat(0.., parse_empty_line),
+        templates: repeat(1.., parse_template),
+    }}.parse_next(i)
+}
+
+#[cfg(test)]
+mod tests {
+    use num_traits::Num;
+    use num_bigint::BigUint;
+    use winnow::error::{ContextError};
+    use crate::parser::{parse_assignment, parse_ast, parse_bus_signal, parse_eol_comment, parse_expression, parse_ff_signal, parse_i64_literal, parse_i64_operand, parse_operator_name, parse_prime, parse_statement, parse_template, parse_template_body, parse_variable_name};
+    use winnow::{Parser};
+    use winnow::token::{take_till};
+    use crate::ast::{Assignment, ComponentsMode, Expr, FfOperand, I64Operand, Signal, Statement, Template, TemplateInstruction, AST};
+
+    #[test]
+    fn test_parse_variable_name() {
+        let mut input = "my_variable_123 = get_signal";
+        let var_name = parse_variable_name.parse_next(&mut input).unwrap();
+        assert_eq!(var_name, "my_variable_123");
+        assert_eq!(input, " = get_signal");
+
+        let mut input = "3my_variable_123 = get_signal";
+        assert!(parse_variable_name.parse_next(&mut input).is_err());
+    }
+
+    #[test]
+    fn test_parse_operator_name() {
+        let mut input = "my_variable_123 = get_signal";
+        let op_name = parse_operator_name.parse_next(&mut input).unwrap();
+        assert_eq!(op_name, "my_variable_123");
+        assert_eq!(input, " = get_signal");
+
+        let mut input = "ff.add = get_signal";
+        let op_name = parse_operator_name.parse_next(&mut input).unwrap();
+        assert_eq!(op_name, "ff.add");
+        assert_eq!(input, " = get_signal");
+    }
+
+    #[test]
+    fn test_i64_operand() {
+        let mut input = "my_variable_123 = get_signal";
+        let want = I64Operand::Variable("my_variable_123".to_string());
+        let op = parse_i64_operand.parse_next(&mut input).unwrap();
+        assert_eq!(op, want);
+
+        let mut input = "i64.4 = get_signal";
+        let want = I64Operand::Literal(4);
+        let op = parse_i64_operand.parse_next(&mut input).unwrap();
+        assert_eq!(op, want);
+
+        let mut input = "i64.93841982938198593829123 = get_signal";
+        let want_err = "\
+i64.93841982938198593829123 = get_signal
+    ^
+invalid i64 literal
+expected valid i64 value";
+        let op = parse_i64_operand.parse(&mut input)
+            .unwrap_err().to_string();
+
+        assert_eq!(op, want_err);
+    }
+
+    #[test]
+    fn test_get_signal() {
+        let mut input = "get_signal x_50";
+        let want = Expr::GetSignal(I64Operand::Variable("x_50".to_string()));
+        let op = parse_expression.parse(&mut input).unwrap();
+        assert_eq!(op, want);
+
+        let mut input = "get_signal i64.2";
+        let want = Expr::GetSignal(I64Operand::Literal(2));
+        let op = parse_expression.parse(&mut input).unwrap();
+        assert_eq!(op, want);
+    }
+
+    #[test]
+    fn test_assignment() {
+        let mut input = "x_4 = get_signal i64.2";
+        let want = Assignment{
+            dest: "x_4".to_string(),
+            value: Expr::GetSignal(I64Operand::Literal(2)),
+        };
+        let a = parse_assignment.parse(&mut input).unwrap();
+        assert_eq!(a, want);
+
+        let mut input = "x_4 = get_signal i64.2 2";
+        assert!(parse_assignment.parse_next(&mut input).is_err());
+
+        let mut input = "x_4 = get_signal i64.2\nxxx";
+        let want = Assignment{
+            dest: "x_4".to_string(),
+            value: Expr::GetSignal(I64Operand::Literal(2)),
+        };
+        let a = parse_assignment.parse_next(&mut input).unwrap();
+        assert_eq!(a, want);
+        assert_eq!(input, "xxx");
+
+        let mut input = "x_4 = get_signal i64.2;;\nxxx";
+        let want = Assignment{
+            dest: "x_4".to_string(),
+            value: Expr::GetSignal(I64Operand::Literal(2)),
+        };
+        let a = parse_assignment.parse_next(&mut input).unwrap();
+        assert_eq!(a, want);
+        assert_eq!(input, "xxx");
+
+        let mut input = "x_4 = get_signal i64.2 ;; comment \nxxx";
+        let want = Assignment{
+            dest: "x_4".to_string(),
+            value: Expr::GetSignal(I64Operand::Literal(2)),
+        };
+        let a = parse_assignment.parse_next(&mut input).unwrap();
+        assert_eq!(a, want);
+        assert_eq!(input, "xxx");
+
+        // test consumes a new line
+        let mut input = "x_1 = get_signal i64.2
+;; OP(MUL)
+x_2 = ff.mul x_0 x_1";
+        let want = Assignment{
+            dest: "x_1".to_string(),
+            value: Expr::GetSignal(I64Operand::Literal(2)),
+        };
+        let a = parse_assignment.parse_next(&mut input).unwrap();
+        assert_eq!(a, want);
+        let want_left = ";; OP(MUL)
+x_2 = ff.mul x_0 x_1";
+        assert_eq!(input, want_left);
+    }
+
+    #[test]
+    fn test_statement() {
+        let mut input = "set_signal i64.0 x_3";
+        let want = Statement::SetSignal {
+            idx: I64Operand::Literal(0),
+            value: FfOperand::Variable("x_3".to_string()),
+        };
+        let a = parse_statement.parse(&mut input).unwrap();
+        assert_eq!(a, want);
+
+        let mut input = "set_signal i64.0 x_3 ;; comment
+x";
+        let want = Statement::SetSignal {
+            idx: I64Operand::Literal(0),
+            value: FfOperand::Variable("x_3".to_string()),
+        };
+        let a = parse_statement.parse_next(&mut input).unwrap();
+        assert_eq!(a, want);
+        assert_eq!("x", input);
+
+        // test spaces in the end of the line
+        let mut input = "set_signal i64.0 x_3
+x";
+        let want = Statement::SetSignal {
+            idx: I64Operand::Literal(0),
+            value: FfOperand::Variable("x_3".to_string()),
+        };
+        let a = parse_statement.parse_next(&mut input).unwrap();
+        assert_eq!(a, want);
+        assert_eq!("x", input);
+    }
+
+    #[test]
+    fn test_3() {
+        let mut input = "i64.93841982938198593829123 = get_signal";
+        let op = parse_i64_literal.parse(&mut input).unwrap_err();
+        println!("{}", op);
+    }
+
+    #[test]
+    fn test_parse_eol_comment() {
+        let mut input = ";; xxx";
+        assert!(parse_eol_comment.parse_next(&mut input).is_ok());
+        assert_eq!(input, "");
+
+        let mut input = ";; xxx
+";
+        assert!(parse_eol_comment.parse_next(&mut input).is_ok());
+        assert_eq!(input, "\n");
+    }
+
+    #[test]
+    fn test_4() {
+        let mut input = ";; xxx";
+        let x = take_till::<_, _, ContextError>(1.., ['x', '\r'])
+            .parse_next(&mut input).unwrap();
+        println!("{}", x);
+        println!("{}", input);
+    }
+
+    #[test]
+    fn test_ff_signal() {
+        let mut input = "ff 0  ff 0 ] [ ff 0 ] [3] [ ]";
+        let want = Signal::Ff(vec![]);
+        let ff_signal = parse_ff_signal.parse_next(&mut input).unwrap();
+        assert_eq!(want, ff_signal);
+        assert_eq!(input, "ff 0 ] [ ff 0 ] [3] [ ]");
+
+        let mut input = "ff 2 4 3  ff 0 ] [ ff 0 ] [3] [ ]";
+        let want = Signal::Ff(vec![4, 3]);
+        let ff_signal = parse_ff_signal.parse_next(&mut input).unwrap();
+        assert_eq!(want, ff_signal);
+        assert_eq!(input, "ff 0 ] [ ff 0 ] [3] [ ]");
+    }
+
+    #[test]
+    fn test_bus_signal() {
+        let mut input = "bus_2 0 ff 0 ] [ ff 0 ] [3] [ ]";
+        let want = Signal::Bus("bus_2".to_string(), vec![]);
+        let bus_signal = parse_bus_signal.parse_next(&mut input).unwrap();
+        assert_eq!(want, bus_signal);
+        assert_eq!(input, "ff 0 ] [ ff 0 ] [3] [ ]");
+
+        let mut input = "bus_2 2 4 3  ff 0 ] [ ff 0 ] [3] [ ]";
+        let want = Signal::Bus("bus_2".to_string(), vec![4, 3]);
+        let bus_signal = parse_bus_signal.parse_next(&mut input).unwrap();
+        assert_eq!(want, bus_signal);
+        assert_eq!(input, "ff 0 ] [ ff 0 ] [3] [ ]");
+    }
+
+    #[test]
+    fn test_template_body() {
+        // the test template is last in the input
+        let mut input = "x_1 = get_signal i64.2
+;; OP(MUL)
+x_2 = ff.mul x_0 x_1
+;; end of compute bucket
+;; OP(ADD)
+x_3 = ff.add x_2 ff.2
+;; end of compute bucket
+;; getting dest
+set_signal i64.0 x_3";
+        let want = vec![
+            TemplateInstruction::Assignment(Assignment{
+                dest: "x_1".to_string(),
+                value: Expr::GetSignal(I64Operand::Literal(2)),
+            }),
+            TemplateInstruction::Assignment(Assignment{
+                dest: "x_2".to_string(),
+                value: Expr::FfMul(FfOperand::Variable("x_0".to_string()),
+                                   FfOperand::Variable("x_1".to_string())),
+            }),
+            TemplateInstruction::Assignment(Assignment{
+                dest: "x_3".to_string(),
+                value: Expr::FfAdd(FfOperand::Variable("x_2".to_string()),
+                                   FfOperand::Literal(BigUint::from(2u32))),
+            }),
+            TemplateInstruction::Statement(Statement::SetSignal {
+                idx: I64Operand::Literal(0),
+                value: FfOperand::Variable("x_3".to_string()),
+            }),
+        ];
+        let template_body = parse_template_body.parse_next(&mut input).unwrap();
+        assert_eq!(want, template_body);
+        assert_eq!(input, "");
+
+        // the test template is NOT last in the input
+        let mut input = "x_2 = ff.mul x_0 x_1
+;; end of compute bucket
+;; getting dest
+set_signal i64.0 x_2
+;; end of store bucket
+
+
+%%template Tmpl2_1 [ ff 1 3] [ ff 0 ] [4] [ ]
+;; store bucket. Line 26";
+        let want = vec![
+            TemplateInstruction::Assignment(Assignment{
+                dest: "x_2".to_string(),
+                value: Expr::FfMul(FfOperand::Variable("x_0".to_string()),
+                                   FfOperand::Variable("x_1".to_string())),
+            }),
+            TemplateInstruction::Statement(Statement::SetSignal {
+                idx: I64Operand::Literal(0),
+                value: FfOperand::Variable("x_2".to_string()),
+            }),
+        ];
+        let template_body = parse_template_body.parse_next(&mut input).unwrap();
+        assert_eq!(want, template_body);
+        assert_eq!(input, "%%template Tmpl2_1 [ ff 1 3] [ ff 0 ] [4] [ ]
+;; store bucket. Line 26");
+    }
+
+    #[test]
+    fn test_parse_template() {
+        let mut input = "%%template Multiplier_0 [ ff 0  ff 0 ] [ ff 0 ] [3] [ ]
+;; store bucket. Line 15
+;; getting src
+;; compute bucket
+;; compute bucket
+;; load bucket
+;; end of load bucket
+x_0 = get_signal i64.1
+;; load bucket
+;; end of load bucket
+x_1 = get_signal i64.2
+;; OP(MUL)
+x_2 = ff.mul x_0 x_1
+;; end of compute bucket
+;; OP(ADD)
+x_3 = ff.add x_2 ff.2
+;; end of compute bucket
+;; getting dest
+set_signal i64.0 x_3
+;; end of store bucket";
+        let want = Template {
+            name: "Multiplier_0".to_string(),
+            outputs: vec![Signal::Ff(vec![]), Signal::Ff(vec![])],
+            inputs: vec![Signal::Ff(vec![])],
+            signals_num: 3,
+            components: vec![],
+            body: vec![
+                TemplateInstruction::Assignment(Assignment{
+                    dest: "x_0".to_string(),
+                    value: Expr::GetSignal(I64Operand::Literal(1)),
+                }),
+                TemplateInstruction::Assignment(Assignment{
+                    dest: "x_1".to_string(),
+                    value: Expr::GetSignal(I64Operand::Literal(2)),
+                }),
+                TemplateInstruction::Assignment(Assignment{
+                    dest: "x_2".to_string(),
+                    value: Expr::FfMul(FfOperand::Variable("x_0".to_string()),
+                                       FfOperand::Variable("x_1".to_string())),
+                }),
+                TemplateInstruction::Assignment(Assignment{
+                    dest: "x_3".to_string(),
+                    value: Expr::FfAdd(FfOperand::Variable("x_2".to_string()),
+                                       FfOperand::Literal(BigUint::from(2u32))),
+                }),
+                TemplateInstruction::Statement(Statement::SetSignal {
+                    idx: I64Operand::Literal(0),
+                    value: FfOperand::Variable("x_3".to_string()),
+                }),
+            ],
+        };
+        let tmpl_header = parse_template.parse_next(&mut input).unwrap();
+        assert_eq!(want, tmpl_header);
+
+        let mut input = "%%template Multiplier_3 [ ] [] [3] [ 0 -1 2 2]
+;; store bucket. Line 15
+;; getting src
+;; compute bucket
+;; compute bucket
+;; load bucket
+;; end of load bucket
+x_0 = get_signal i64.1
+;; load bucket
+;; end of load bucket
+x_1 = get_signal i64.2
+;; OP(MUL)
+x_2 = ff.mul x_0 x_1
+;; end of compute bucket
+;; OP(ADD)
+x_3 = ff.add x_2 ff.2
+;; end of compute bucket
+;; getting dest
+set_signal i64.0 x_3
+;; end of store bucket
+
+%%template Multiplier_0 [ ff 0  ff 0 ] [ ff 0 ] [3] [ ]";
+        let want = Template {
+            name: "Multiplier_3".to_string(),
+            outputs: vec![],
+            inputs: vec![],
+            signals_num: 3,
+            components: vec![Some(0), None, Some(2), Some(2)],
+            body: vec![
+                TemplateInstruction::Assignment(Assignment{
+                    dest: "x_0".to_string(),
+                    value: Expr::GetSignal(I64Operand::Literal(1)),
+                }),
+                TemplateInstruction::Assignment(Assignment{
+                    dest: "x_1".to_string(),
+                    value: Expr::GetSignal(I64Operand::Literal(2)),
+                }),
+                TemplateInstruction::Assignment(Assignment{
+                    dest: "x_2".to_string(),
+                    value: Expr::FfMul(FfOperand::Variable("x_0".to_string()),
+                                       FfOperand::Variable("x_1".to_string())),
+                }),
+                TemplateInstruction::Assignment(Assignment{
+                    dest: "x_3".to_string(),
+                    value: Expr::FfAdd(FfOperand::Variable("x_2".to_string()),
+                                       FfOperand::Literal(BigUint::from(2u32))),
+                }),
+                TemplateInstruction::Statement(Statement::SetSignal {
+                    idx: I64Operand::Literal(0),
+                    value: FfOperand::Variable("x_3".to_string()),
+                }),
+            ],
+        };
+        let tmpl_header = parse_template.parse_next(&mut input).unwrap();
+        assert_eq!(want, tmpl_header);
+        assert_eq!("%%template Multiplier_0 [ ff 0  ff 0 ] [ ff 0 ] [3] [ ]", input);
+    }
+
+    #[test]
+    fn test_parse_ast() {
+        let mut input = ";; Prime value
+%%prime 21888242871839275222246405745257275088548364400416034343698204186575808495617
+
+;; Memory of signals
+%%signals 4
+
+;; Heap of components
+%%components_heap 3
+
+;; Main template
+%%start Multiplier_0
+
+;; Component creation mode (implicit/explicit)
+%%components explicit
+
+;; Witness (signal list)
+%%witness 0 1 2 3
+
+%%template Multiplier_0 [ ff 0  ff 0 ] [ ff 0 ] [3] [ ]
+;; store bucket. Line 15
+x_0 = get_signal i64.1
+;; end of load bucket
+x_1 = get_signal i64.2
+
+%%template Multiplier_1 [ ff 0  ff 0 ] [ ff 0 ] [3] [ ]
+;; store bucket. Line 15
+x_0 = get_signal i64.1
+;; end of load bucket
+x_1 = get_signal i64.2
+";
+        let want = AST {
+            prime: BigUint::from_str_radix(
+                "21888242871839275222246405745257275088548364400416034343698204186575808495617",
+                10).unwrap(),
+            signals: 4,
+            components_heap: 3,
+            start: "Multiplier_0".to_string(),
+            components_mode: ComponentsMode::Explicit,
+            witness: vec![0, 1, 2, 3],
+            templates: vec![
+                Template {
+                    name: "Multiplier_0".to_string(),
+                    outputs: vec![Signal::Ff(vec![]), Signal::Ff(vec![])],
+                    inputs: vec![Signal::Ff(vec![])],
+                    signals_num: 3,
+                    components: vec![],
+                    body: vec![
+                        TemplateInstruction::Assignment(Assignment{
+                            dest: "x_0".to_string(),
+                            value: Expr::GetSignal(I64Operand::Literal(1)),
+                        }),
+                        TemplateInstruction::Assignment(Assignment{
+                            dest: "x_1".to_string(),
+                            value: Expr::GetSignal(I64Operand::Literal(2)),
+                        }),
+                    ],
+                },
+                Template {
+                    name: "Multiplier_1".to_string(),
+                    outputs: vec![Signal::Ff(vec![]), Signal::Ff(vec![])],
+                    inputs: vec![Signal::Ff(vec![])],
+                    signals_num: 3,
+                    components: vec![],
+                    body: vec![
+                        TemplateInstruction::Assignment(Assignment{
+                            dest: "x_0".to_string(),
+                            value: Expr::GetSignal(I64Operand::Literal(1)),
+                        }),
+                        TemplateInstruction::Assignment(Assignment{
+                            dest: "x_1".to_string(),
+                            value: Expr::GetSignal(I64Operand::Literal(2)),
+                        }),
+                    ],
+                },
+            ],
+        };
+        let tmpl_header = consume_parse_result(parse_ast.parse(&mut input));
+        assert_eq!(want, tmpl_header);
+    }
+
+    fn consume_parse_result<T, E: std::fmt::Display>(x: winnow::error::Result<T, E>) -> T {
+        match x {
+            Ok(x) => x,
+            Err(e) => {
+                println!("Error:\n{}", e);
+                panic!();
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_prime() {
+        // no newline
+        let mut input = "%%prime 21888242871839275222246405745257275088548364400416034343698204186575808495617";
+        let want_err = "\
+%%prime 21888242871839275222246405745257275088548364400416034343698204186575808495617
+                                                                                     ^
+expected newline";
+        let r = parse_prime.parse(&mut input);
+        assert!(r.is_err());
+        let err = r.unwrap_err().to_string();
+        assert_eq!(err, want_err);
+
+        // ok
+        let mut input = "%%prime 21888242871839275222246405745257275088548364400416034343698204186575808495617
+x";
+        let want = BigUint::from_str_radix("21888242871839275222246405745257275088548364400416034343698204186575808495617", 10).unwrap();
+        let prime = parse_prime.parse_next(&mut input).unwrap();
+        assert_eq!(want, prime);
+        assert_eq!(input, "x");
+
+        // parse
+        let mut input = "%%prime 21888242871839275222246405745257275088548364400416034343698204186575808495617\n";
+        let prime = consume_parse_result(parse_prime.parse(&mut input));
+        assert_eq!(want, prime);
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -216,7 +216,9 @@ fn parse_assignment(input: &mut &str) -> ModalResult<Assignment> {
     let (var_name, _, _, _, expr, _, _, _) = seq!(
         parse_variable_name,
         space0, literal("="), space0,
-        parse_expression,
+        cut_err(parse_expression
+            .context(StrContext::Label("expression"))
+            .context(StrContext::Expected(StrContextValue::Description("valid expression")))),
         space0,
         opt(parse_eol_comment),
         parse_line_end)
@@ -247,6 +249,8 @@ fn parse_expression(input: &mut &str) -> ModalResult<Expr> {
             .map(|(op1, op2)| Expr::FfMul(op1, op2)),
         "ff.add" => (preceded(space1, parse_ff_operand), preceded(space1, parse_ff_operand))
             .map(|(op1, op2)| Expr::FfAdd(op1, op2)),
+        "ff.neq" => (preceded(space1, parse_ff_operand), preceded(space1, parse_ff_operand))
+            .map(|(op1, op2)| Expr::FfNeq(op1, op2)),
         // "get_signal" => {
         //     Ok(Expr::GetSignal(I64Operand::Literal(0)))
         // },

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -367,7 +367,7 @@ fn parse_template(i: &mut &str) -> ModalResult<Template> {
     }}.parse_next(i)
 }
 
-fn parse_ast(i: &mut &str) -> ModalResult<AST> {
+pub fn parse_ast(i: &mut &str) -> ModalResult<AST> {
     seq!{AST{
         _: repeat(0.., parse_empty_line),
         prime: parse_prime

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,6 +1,6 @@
 use num_bigint::BigUint;
 use winnow::ascii::{digit1, space0, space1, line_ending, alpha1};
-use winnow::error::{AddContext, ContextError, ErrMode, ParserError, StrContext, StrContextValue};
+use winnow::error::{ContextError, ErrMode, ParserError, StrContext, StrContextValue};
 use winnow::{ModalResult};
 use winnow::combinator::{alt, preceded, repeat, terminated, seq, dispatch, fail, opt, cut_err, trace, eof, delimited};
 use winnow::Parser;
@@ -369,25 +369,25 @@ fn parse_template(i: &mut &str) -> ModalResult<Template> {
 
 pub fn parse_ast(i: &mut &str) -> ModalResult<AST> {
     seq!{AST{
-        _: repeat(0.., parse_empty_line),
+        _: repeat::<_, _, (), _, _>(0.., parse_empty_line),
         prime: parse_prime
             .context(StrContext::Expected(StrContextValue::StringLiteral("%%prime"))),
-        _: repeat(0.., parse_empty_line),
+        _: repeat::<_, _, (), _, _>(0.., parse_empty_line),
         signals: parse_signals_num
             .context(StrContext::Expected(StrContextValue::StringLiteral("%%signals"))),
-        _: repeat(0.., parse_empty_line),
+        _: repeat::<_, _, (), _, _>(0.., parse_empty_line),
         components_heap: parse_components_heap
             .context(StrContext::Expected(StrContextValue::StringLiteral("%%components_heap"))),
-        _: repeat(0.., parse_empty_line),
+        _: repeat::<_, _, (), _, _>(0.., parse_empty_line),
         start: parse_start_template
             .context(StrContext::Expected(StrContextValue::StringLiteral("%%start"))),
-        _: repeat(0.., parse_empty_line),
+        _: repeat::<_, _, (), _, _>(0.., parse_empty_line),
         components_mode: parse_components_creation_mode
             .context(StrContext::Expected(StrContextValue::StringLiteral("%%components"))),
-        _: repeat(0.., parse_empty_line),
+        _: repeat::<_, _, (), _, _>(0.., parse_empty_line),
         witness: parse_witness_list
             .context(StrContext::Expected(StrContextValue::StringLiteral("%%witness"))),
-        _: repeat(0.., parse_empty_line),
+        _: repeat::<_, _, (), _, _>(0.., parse_empty_line),
         templates: repeat(1.., parse_template),
     }}.parse_next(i)
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,6 +1,6 @@
 use num_bigint::BigUint;
 use winnow::ascii::{digit1, space0, space1, line_ending, alpha1};
-use winnow::error::{ContextError, ErrMode, ParserError, StrContext, StrContextValue};
+use winnow::error::{ContextError, ErrMode, ParseError, ParserError, StrContext, StrContextValue};
 use winnow::{ModalResult};
 use winnow::combinator::{alt, preceded, repeat, terminated, seq, dispatch, fail, opt, cut_err, trace, eof, delimited};
 use winnow::Parser;
@@ -367,7 +367,7 @@ fn parse_template(i: &mut &str) -> ModalResult<Template> {
     }}.parse_next(i)
 }
 
-pub fn parse_ast(i: &mut &str) -> ModalResult<AST> {
+fn parse_ast(i: &mut &str) -> ModalResult<AST> {
     seq!{AST{
         _: repeat::<_, _, (), _, _>(0.., parse_empty_line),
         prime: parse_prime
@@ -390,6 +390,10 @@ pub fn parse_ast(i: &mut &str) -> ModalResult<AST> {
         _: repeat::<_, _, (), _, _>(0.., parse_empty_line),
         templates: repeat(1.., parse_template),
     }}.parse_next(i)
+}
+
+pub fn parse(i: &str) -> Result<AST, ParseError<&str, ContextError>> {
+    parse_ast.parse(i)
 }
 
 #[cfg(test)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -603,13 +603,13 @@ mod tests {
         let mut r = WriteBackReader::new(std::io::Cursor::new(&data));
 
         let buf = &mut [0u8; 5];
-        r.read(buf).unwrap();
+        r.read_exact(buf).unwrap();
         assert_eq!(buf, &[1, 2, 3, 4, 5]);
 
         // return [4, 5] to reader
-        r.write(&buf[3..]).unwrap();
+        r.write_all(&buf[3..]).unwrap();
         // return [2, 3] to reader
-        r.write(&buf[1..3]).unwrap();
+        r.write_all(&buf[1..3]).unwrap();
 
         buf.fill(0);
 

--- a/src/storage/proto_deserializer.rs
+++ b/src/storage/proto_deserializer.rs
@@ -12,10 +12,10 @@ pub fn deserialize_witnesscalc_graph_from_bytes(
 ) -> std::io::Result<(Box<dyn NodesInterface>, Vec<usize>, InputSignalsInfo)> {
 
     if bytes.len() < WITNESSCALC_GRAPH_MAGIC.len() {
-        return Err(Error::new(ErrorKind::Other, "Invalid magic"));
+        return Err(Error::other("Invalid magic"));
     }
     if !bytes[..WITNESSCALC_GRAPH_MAGIC.len()].eq(WITNESSCALC_GRAPH_MAGIC) {
-        return Err(Error::new(ErrorKind::Other, "Invalid magic"));
+        return Err(Error::other("Invalid magic"));
     }
 
     let mut idx: usize = WITNESSCALC_GRAPH_MAGIC.len();

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -865,7 +865,7 @@ pub fn execute(
                     (&templates[template_id].line_numbers, templates[template_id].name.as_str())
                 }
                 Frame::Function { function, .. } => {
-                    (&(*function).line_numbers, function.name.as_str())
+                    (&function.line_numbers, function.name.as_str())
                 }
             };
             disassemble_instruction(code, line_numbers, ip, name, functions);

--- a/src/vm2.rs
+++ b/src/vm2.rs
@@ -24,9 +24,10 @@ pub enum OpCode {
     OpAdd           = 9,
 }
 
-pub struct Circuit {
+pub struct Circuit<T: FieldOps> {
     pub main_template_id: usize,
     pub templates: Vec<Template>,
+    pub prime: T,
 }
 
 pub struct Template {

--- a/src/vm2.rs
+++ b/src/vm2.rs
@@ -282,8 +282,6 @@ pub fn execute<F: FieldOperations>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
     fn test_ok() {
         let x: &[u8] = &[1, 2, 3];

--- a/src/vm2.rs
+++ b/src/vm2.rs
@@ -48,6 +48,13 @@ pub enum OpCode {
     OpEqz                = 19,
 }
 
+pub struct Component {
+    pub signals_start: usize,
+    pub template_id: usize,
+    pub omponents: Vec<Option<Box<Component>>>,
+    pub number_of_inputs: usize,
+}
+
 pub struct Circuit<T: FieldOps> {
     pub main_template_id: usize,
     pub templates: Vec<Template>,

--- a/src/vm2.rs
+++ b/src/vm2.rs
@@ -30,7 +30,8 @@ pub struct Circuit<T: FieldOps> {
     pub templates: Vec<Template>,
     pub prime: T,
     pub witness: Vec<usize>,
-    pub input_signals_info: HashMap<String, usize>
+    pub input_signals_info: HashMap<String, usize>,
+    pub signals_num: usize,
 }
 
 pub struct Template {

--- a/src/vm2.rs
+++ b/src/vm2.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::error::Error;
 use crate::field::FieldOps;
 
@@ -29,6 +30,7 @@ pub struct Circuit<T: FieldOps> {
     pub templates: Vec<Template>,
     pub prime: T,
     pub witness: Vec<usize>,
+    pub input_signals_info: HashMap<String, usize>
 }
 
 pub struct Template {

--- a/src/vm2.rs
+++ b/src/vm2.rs
@@ -7,6 +7,9 @@ pub enum OpCode {
     // Put signals to the stack
     // required stack_i64: signal index
     LoadSignal      = 1,
+    // Store the signal
+    // stack_ff contains the value to store
+    // stack_i64 contains the signal index
     StoreSignal     = 2,
     PushI64         = 3, // Push i64 value to the stack
     PushFf          = 4, // Push i64 value to the stack
@@ -31,9 +34,50 @@ fn read_instruction(code: &[u8], ip: usize) -> OpCode {
 
 pub enum RuntimeError {
     StackUnderflow,
+    StackVariableIsNotSet,
     I32ToUsizeConversion,
     SignalIndexOutOfBounds,
     SignalIsNotSet,
+    SignalIsAlreadySet,
+}
+
+struct VM<T: FieldOps> {
+    stack_ff: Vec<Option<T>>,
+    stack_i64: Vec<Option<i64>>,
+}
+
+impl<T: FieldOps> VM<T> {
+    fn new() -> Self {
+        Self {
+            stack_ff: Vec::new(),
+            stack_i64: Vec::new(),
+        }
+    }
+
+    fn push_ff(&mut self, value: Option<T>) {
+        self.stack_ff.push(value);
+    }
+
+    fn pop_ff(&mut self) -> Result<T, RuntimeError> {
+        self.stack_ff.pop().ok_or(RuntimeError::StackUnderflow)?
+            .ok_or(RuntimeError::StackVariableIsNotSet)
+    }
+
+    fn push_i64(&mut self, value: Option<i64>) {
+        self.stack_i64.push(value);
+    }
+
+    fn pop_i64(&mut self) -> Result<i64, RuntimeError> {
+        self.stack_i64
+            .pop().ok_or(RuntimeError::StackUnderflow)?
+            .ok_or(RuntimeError::StackVariableIsNotSet)
+    }
+
+    fn pop_usize(&mut self) -> Result<usize, RuntimeError> {
+        self.pop_i64()?
+            .try_into()
+            .map_err(|_| RuntimeError::I32ToUsizeConversion)
+    }
 }
 
 pub fn execute<T>(
@@ -43,9 +87,7 @@ where
     T: FieldOps {
 
     let mut ip: usize = 0;
-    let mut stack_ff: Vec<Option<T>> = Vec::new();
-    let mut stack_i64: Vec<Option<i64>> = Vec::new();
-    let mut stack_i64_base: usize = 0;
+    let mut vm = VM::<T>::new();
 
     'label: loop {
         if ip == templates[main_template_id].code.len() {
@@ -58,23 +100,22 @@ where
         match op_code {
             OpCode::NoOp => (),
             OpCode::LoadSignal => {
-                let signal_idx = stack_i64.pop()
-                    // Check that the stack is not empty
-                    .ok_or_else(|| RuntimeError::StackUnderflow)?
-                    // Checkout that the value in the stack is not null
-                    .ok_or_else(|| RuntimeError::StackUnderflow)?;
-
-                let signal_idx: usize = signal_idx.try_into()
-                    .map_err(|_| RuntimeError::I32ToUsizeConversion)?;
-
+                let signal_idx = vm.pop_usize()?;
                 let s = signals.get(signal_idx)
                     .ok_or_else(|| RuntimeError::SignalIndexOutOfBounds)?
                     .ok_or_else(|| RuntimeError::SignalIsNotSet)?;
-                
-                stack_ff.push(Some(s));
+
+                vm.push_ff(Some(s));
             }
             OpCode::StoreSignal => {
-                todo!();
+                let signal_idx = vm.pop_usize()?;
+                if signal_idx >= signals.len() {
+                    return Err(RuntimeError::SignalIndexOutOfBounds);
+                }
+                if signals[signal_idx].is_some() {
+                    return Err(RuntimeError::SignalIsAlreadySet);
+                }
+                signals[signal_idx] = Some(vm.pop_ff()?);
             }
             OpCode::PushI64 => {
                 todo!();

--- a/src/vm2.rs
+++ b/src/vm2.rs
@@ -23,6 +23,7 @@ pub enum OpCode {
     LoadVariableFf  = 7,
     OpMul           = 8,
     OpAdd           = 9,
+    OpNeq           = 10,
 }
 
 pub struct Circuit<T: FieldOps> {
@@ -176,6 +177,9 @@ where
         OpCode::OpAdd => {
             println!("OpAdd");
         }
+        OpCode::OpNeq => {
+            println!("OpNeq");
+        }
     }
 
     ip
@@ -273,6 +277,11 @@ pub fn execute<F: FieldOperations>(
                 let lhs = vm.pop_ff()?;
                 let rhs = vm.pop_ff()?;
                 vm.push_ff(ff.add(lhs, rhs));
+            }
+            OpCode::OpNeq => {
+                let lhs = vm.pop_ff()?;
+                let rhs = vm.pop_ff()?;
+                vm.push_ff(ff.neq(lhs, rhs));
             }
         }
     }

--- a/src/vm2.rs
+++ b/src/vm2.rs
@@ -1,0 +1,24 @@
+#[repr(u8)]
+#[derive(Debug)]
+pub enum OpCode {
+    NoOp = 0,
+    // Put signals to the stack
+    // required stack_i64: signal index
+    LoadSignal      = 1,
+    StoreSignal     = 2,
+    PushI64         = 3, // Push i64 value to the stack
+    PushFf          = 4, // Push i64 value to the stack
+    // Set variables from the stack
+    // arguments:      offset from the base pointer
+    // required stack: values to store equal to variables number from arguments
+    StoreVariable   = 5,
+    LoadVariableI64 = 6,
+    LoadVariableFf  = 7,
+    OpMul           = 8,
+    OpAdd           = 9,
+}
+
+pub struct Template {
+    pub name: String,
+    pub code: Vec<u8>,
+}

--- a/src/vm2.rs
+++ b/src/vm2.rs
@@ -28,6 +28,7 @@ pub struct Circuit<T: FieldOps> {
     pub main_template_id: usize,
     pub templates: Vec<Template>,
     pub prime: T,
+    pub witness: Vec<usize>,
 }
 
 pub struct Template {
@@ -65,7 +66,7 @@ struct VM<T: FieldOps> {
     stack_ff: Vec<Option<T>>,
     stack_i64: Vec<Option<i64>>,
     base_pointer_ff: usize,
-    base_pointer_i64: usize,
+    // base_pointer_i64: usize,
 }
 
 impl<T: FieldOps> VM<T> {
@@ -74,7 +75,7 @@ impl<T: FieldOps> VM<T> {
             stack_ff: Vec::new(),
             stack_i64: Vec::new(),
             base_pointer_ff: 0,
-            base_pointer_i64: 0,
+            // base_pointer_i64: 0,
         }
     }
 
@@ -158,8 +159,8 @@ where
             println!("StoreVariableFf: {}", var_idx);
         }
         OpCode::LoadVariableI64 => {
-            todo!();
             println!("LoadVariableI64");
+            todo!();
         }
         OpCode::LoadVariableFf => {
             let var_idx: usize;

--- a/src/vm2.rs
+++ b/src/vm2.rs
@@ -1,35 +1,57 @@
 use std::collections::HashMap;
 use std::error::Error;
-use crate::field::{FieldOperations, FieldOps};
+use crate::field::{Field, FieldOperations, FieldOps};
 
 #[repr(u8)]
 #[derive(Debug)]
 pub enum OpCode {
-    NoOp = 0,
+    NoOp                 = 0,
     // Put signals to the stack
     // required stack_i64: signal index
-    LoadSignal      = 1,
+    LoadSignal           = 1,
     // Store the signal
     // stack_ff contains the value to store
     // stack_i64 contains the signal index
-    StoreSignal     = 2,
-    PushI64         = 3, // Push i64 value to the stack
-    PushFf          = 4, // Push ff value to the stack
+    StoreSignal          = 2,
+    PushI64              = 3, // Push i64 value to the stack
+    PushFf               = 4, // Push ff value to the stack
     // Set variables from the stack
     // arguments:      offset from the base pointer
     // required stack: values to store equal to variables number from arguments
-    StoreVariableFf = 5,
-    LoadVariableI64 = 6,
-    LoadVariableFf  = 7,
-    OpMul           = 8,
-    OpAdd           = 9,
-    OpNeq           = 10,
+    StoreVariableFf      = 5,
+    LoadVariableI64      = 6,
+    LoadVariableFf       = 7,
+    // Jump to the instruction
+    // arguments:      4 byte LE offset to jump
+    // required stack: the ff value to check for failure
+    JumpIfFalse          = 8,
+    // Jump to the instruction
+    // arguments:      4 byte LE offset to jump
+    Jump                 = 9,
+    // stack_i64 contains the error code
+    Error                = 10,
+    // Get the component signal and put it to the stack_ff
+    // stack_i64:0 contains the signal index
+    // stack_i64:-1 contains the component index
+    LoadCmpSignal        = 11,
+    // Store the component signal and run
+    // stack_ff contains the value to store
+    // stack_i64:0 contains the signal index
+    // stack_i64:-1 contains the component index
+    StoreCmpSignalAndRun = 12,
+    OpMul                = 13,
+    OpAdd                = 14,
+    OpNeq                = 15,
+    OpDiv                = 16,
+    OpSub                = 17,
+    OpEq                 = 18,
+    OpEqz                = 19,
 }
 
 pub struct Circuit<T: FieldOps> {
     pub main_template_id: usize,
     pub templates: Vec<Template>,
-    pub prime: T,
+    pub field: Field<T>,
     pub witness: Vec<usize>,
     pub input_signals_info: HashMap<String, usize>,
     pub signals_num: usize,
@@ -171,6 +193,22 @@ where
             (var_idx, ip) = usize_from_code(code, ip).unwrap();
             println!("LoadVariableFf: {}", var_idx);
         }
+        OpCode::JumpIfFalse => {
+            let v = i32::from_le_bytes((&code[ip..ip+size_of::<i32>()]).try_into().unwrap());
+            ip += size_of::<i32>();
+            println!("JumpIfFalse: {}", v);
+        }
+        OpCode::Jump => {
+            let v = i32::from_le_bytes((&code[ip..ip+size_of::<i32>()]).try_into().unwrap());
+            ip += size_of::<i32>();
+            println!("Jump: {}", v);
+        }
+        OpCode::LoadCmpSignal => {
+            println!("LoadCmpSignal");
+        }
+        OpCode::StoreCmpSignalAndRun => {
+            println!("StoreCmpSignalAndRun");
+        }
         OpCode::OpMul => {
             println!("OpMul");
         }
@@ -179,6 +217,21 @@ where
         }
         OpCode::OpNeq => {
             println!("OpNeq");
+        }
+        OpCode::OpDiv => {
+            println!("OpDiv");
+        }
+        OpCode::OpSub => {
+            println!("OpSub");
+        }
+        OpCode::OpEq => {
+            println!("OpEq");
+        }
+        OpCode::OpEqz => {
+            println!("OpEqz");
+        }
+        OpCode::Error => {
+            println!("Error");
         }
     }
 
@@ -282,6 +335,33 @@ pub fn execute<F: FieldOperations>(
                 let lhs = vm.pop_ff()?;
                 let rhs = vm.pop_ff()?;
                 vm.push_ff(ff.neq(lhs, rhs));
+            }
+            OpCode::LoadCmpSignal => {
+                todo!()
+            }
+            OpCode::StoreCmpSignalAndRun => {
+                todo!()
+            }
+            OpCode::JumpIfFalse => {
+                todo!()
+            }
+            OpCode::Error => {
+                todo!()
+            }
+            OpCode::Jump => {
+                todo!()
+            }
+            OpCode::OpDiv => {
+                todo!()
+            }
+            OpCode::OpSub => {
+                todo!()
+            }
+            OpCode::OpEq => {
+                todo!()
+            }
+            OpCode::OpEqz => {
+                todo!()
             }
         }
     }

--- a/src/vm2.rs
+++ b/src/vm2.rs
@@ -211,8 +211,8 @@ pub fn execute<F: FieldOperations>(
             OpCode::LoadSignal => {
                 let signal_idx = template_signals_start + vm.pop_usize()?;
                 let s = signals.get(signal_idx)
-                    .ok_or_else(|| RuntimeError::SignalIndexOutOfBounds)?
-                    .ok_or_else(|| RuntimeError::SignalIsNotSet)?;
+                    .ok_or(RuntimeError::SignalIndexOutOfBounds)?
+                    .ok_or(RuntimeError::SignalIsNotSet)?;
 
                 vm.push_ff(s);
             }

--- a/test_circuits_vm2.sh
+++ b/test_circuits_vm2.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+set -eu
+
+required_commands=(circom snarkjs cargo node cmp)
+
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+for cmd in "${required_commands[@]}"; do
+	if ! command -v "$cmd" &> /dev/null; then
+		echo -e "${RED}\`$cmd\` command could not be found${NC}"
+		exit 1
+	fi
+done
+
+if ! circom --help | grep -q "\-\-cvm"; then
+  echo -e "${RED}found circom version does not support --cvm flag.${NC}"
+  exit 1
+fi
+
+workdir="$(pwd)/test_working_dir_vm2"
+
+if [ ! -d "$workdir" ]; then
+	echo "Creating working directory $workdir"
+	mkdir "$workdir"
+fi
+
+print_usage() {
+    echo "Usage: $0 [-h] [-l <inlcude_path>] [file1 ...]"
+    echo
+    echo "Options:"
+    echo "  -l <include_path>      Path to include directory. Can be specified multiple times"
+    echo "  -h                     Print this usage and exit"
+    echo
+    echo "Positional Arguments:"
+    echo "  file1       Circom circuit file. May be multiple. If none provided, all circuits in test_circuits/ directory processed."
+    echo
+    echo "Examples:"
+    echo "  $0 test_circuits/circuit1.circom"
+}
+
+declare -a library_paths
+
+while getopts ":p:l:h" opt; do
+  case $opt in
+    h)
+        print_usage
+        exit 0
+        ;;
+    l)
+        library_paths+=("$OPTARG")
+        ;;
+    :)
+        echo "Error: -$OPTARG requires a value" >&2;
+        exit 1
+        ;;
+    \?)
+        echo "Error: Invalid option -$OPTARG" >&2;
+        exit 1
+        ;;
+  esac
+done
+
+# Shift past the named options to access positional arguments
+shift $((OPTIND - 1))
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+echo "script dir ${script_dir}"
+
+if [ ${#library_paths} -eq 0 ]; then
+    library_paths+=("${script_dir}/test_deps/circomlib/circuits")
+fi
+
+declare -a include_args
+
+for arg in "${library_paths[@]}"; do
+    if [ ! -d "$arg" ]; then
+      echo -e "${RED}include path not found at $arg${NC}"
+      exit 1
+    fi
+    include_args+=("-l" "$arg")
+done
+
+pushd "${script_dir}" > /dev/null
+cargo build --release
+popd > /dev/null
+
+function test_circuit() {
+  local circuit_path=$1
+  echo "Running $circuit_path"
+  local circuit_name="$(basename "$circuit_path")" && circuit_name="${circuit_name%%.*}"
+  local inputs_path="$(dirname "$circuit_path")/${circuit_name}_inputs.json"
+  pwd
+  if [ ! -f "$inputs_path" ]; then
+    echo -e "${RED}Inputs file not found at $inputs_path${NC}"
+    exit 1
+  fi
+  local circuit_bytecode_path="${workdir}/${circuit_name}_bc2.wcd"
+  local witness_path="${workdir}/${circuit_name}.wtns"
+  local r1cs_path="${workdir}/${circuit_name}.r1cs"
+  local sym_path="${workdir}/${circuit_name}.sym"
+  local cvm_path="${workdir}/${circuit_name}_cvm/${circuit_name}.cvm"
+
+  pushd "$workdir" > /dev/null
+
+  # Run Circom to generate assembly file.
+  circom --r1cs --sym --cvm --wasm "${include_args[@]}" "$circuit_path"
+
+  # run commands from the project directory
+  pushd "${script_dir}" > /dev/null
+
+  time target/release/cvm-compile \
+    "$cvm_path" "$sym_path" "${circuit_bytecode_path}" \
+    --wtns "${witness_path}" --inputs "${inputs_path}" \
+
+  popd > /dev/null
+
+  echo "Generate WASM witness"
+  time node "${circuit_name}"_js/generate_witness.js "${circuit_name}"_js/"${circuit_name}".wasm "${inputs_path}" "${witness_path}2"
+
+  snarkjs wej "${witness_path}" "${witness_path}.json"
+  snarkjs wej "${witness_path}2" "${witness_path}2.json"
+
+  echo "Check CVM witness"
+  snarkjs wtns check "${r1cs_path}" "${witness_path}"
+  echo "Check WASM witness"
+  snarkjs wtns check "${r1cs_path}" "${witness_path}2"
+
+  if ! cmp -s "${witness_path}" "${witness_path}2"; then
+    echo -e "${RED}Witnesses do not match${NC}"
+    exit 1
+  fi
+
+  popd > /dev/null
+}
+
+if [ $# -gt 0 ]; then
+  for arg in "$@"; do
+    circuit_path=$(realpath "$arg")
+    if [ ! -f "$circuit_path" ]; then
+      echo -e "${RED}Circuit file not found at $circuit_path${NC}"
+      exit 1
+    fi
+    test_circuit "${circuit_path}"
+  done
+else
+  for circuit_path in "${script_dir}"/test_circuits/*.circom; do
+    circuit_path=$(realpath "$circuit_path")
+    test_circuit "${circuit_path}"
+  done
+fi

--- a/test_circuits_vm2.sh
+++ b/test_circuits_vm2.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eux
 
 required_commands=(circom snarkjs cargo node cmp)
 


### PR DESCRIPTION
The parse branch introduces a CVM (Circom Virtual Machine) parser and execution engine as an alternative to WASM-based witness calculation:
Major Additions:
1. CVM Parser Infrastructure
  - src/ast.rs: Defines AST for CVM assembly language with directives, templates, and instructions
  - src/parser/mod.rs: Winnow-based parser to parse .cvm files into AST
  - Added dependencies: winnow (parser combinator) and thiserror (error handling)
2. New VM2 Implementation (src/vm2.rs)
  - Simplified bytecode VM with streamlined opcodes
  - Stack-based execution with separate i64 and field element stacks
  - Direct bytecode execution instead of graph-based approach
3. CVM Compilation Binary (src/bin/cvm-compile.rs)
  - Compiles CVM assembly files to bytecode (.wcd files)
  - Supports optimization passes and instruction reordering
  - Generates compact bytecode representation
4. Test Infrastructure
  - test_circuits_vm2.sh: Tests CVM path (circom → CVM → bytecode → witness)
  - Compares witness generation between WASM and VM2 paths
Key Modifications:
1. Field Operations (src/field.rs)
  - Added BYTES constant to trait
  - Added bn254_prime constant
  - Improved negative number parsing
  - Made Field struct Clone
2. Graph Optimizations (src/graph.rs)
  - Simplified constant folding in push method
  - More direct node handling
  - Removed some recursive evaluation methods
Purpose:
The parse branch provides an alternative execution path for Circom circuits that bypasses WASM:
- Traditional: Circom → WASM → witness
- New CVM path: Circom → CVM assembly → bytecode → VM2 → witness
This offers potentially better performance and more control over optimization compared to the WASM runtime approach.