### PR TITLE
perf: speed up bn254 multiplication with arkworks Fr

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -272,6 +272,9 @@ pub const bn254_prime: U254 = uint!(21888242871839275222246405745257275088548364
 #[inline]
 fn mul_bn254_u254(a: U254, b: U254) -> U254 {
     debug_assert_eq!(fr_modulus_u254(), bn254_prime);
+    // Keep this guard mirrored with graph.rs::mul_bn254_u256.
+    // Noncanonical values can come from integer-style operations; keep those on
+    // the legacy path. The multi-limb check is only a performance gate.
     if a < bn254_prime && b < bn254_prime && is_multi_limb_u254(a) && is_multi_limb_u254(b) {
         fr_to_u254(u254_to_fr_canonical(a) * u254_to_fr_canonical(b))
     } else {
@@ -287,6 +290,7 @@ fn is_multi_limb_u254(v: U254) -> bool {
 
 #[inline]
 fn u254_to_fr_canonical(v: U254) -> Fr {
+    // Caller must ensure the value is canonical for Fr::from_bigint.
     debug_assert!(v < bn254_prime);
     Fr::from_bigint(BigInt(v.into_limbs())).unwrap()
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -4,6 +4,8 @@ use std::hash::{Hash, Hasher};
 use std::num::{TryFromIntError};
 use std::ops::{Add, Mul, Div, Rem, Sub, Shr, Shl, BitAnd, BitOr, BitXor, Not};
 use anyhow::anyhow;
+use ark_bn254::Fr;
+use ark_ff::{BigInt, PrimeField};
 use ruint::{aliases::U256, uint};
 use ruint::aliases::U128;
 use num_traits::{Zero, One};
@@ -267,6 +269,38 @@ pub type U254 = ruint::Uint<254, 4>;
 
 pub const bn254_prime: U254 = uint!(21888242871839275222246405745257275088548364400416034343698204186575808495617_U254);
 
+#[inline]
+fn mul_bn254_u254(a: U254, b: U254) -> U254 {
+    debug_assert_eq!(fr_modulus_u254(), bn254_prime);
+    if a < bn254_prime && b < bn254_prime && is_multi_limb_u254(a) && is_multi_limb_u254(b) {
+        fr_to_u254(u254_to_fr_canonical(a) * u254_to_fr_canonical(b))
+    } else {
+        <U254>::mul_mod(a, b, bn254_prime)
+    }
+}
+
+#[inline]
+fn is_multi_limb_u254(v: U254) -> bool {
+    let limbs = v.into_limbs();
+    limbs[1] != 0 || limbs[2] != 0 || limbs[3] != 0
+}
+
+#[inline]
+fn u254_to_fr_canonical(v: U254) -> Fr {
+    debug_assert!(v < bn254_prime);
+    Fr::from_bigint(BigInt(v.into_limbs())).unwrap()
+}
+
+#[inline]
+fn fr_to_u254(v: Fr) -> U254 {
+    U254::from_limbs(v.into_bigint().0)
+}
+
+#[inline]
+fn fr_modulus_u254() -> U254 {
+    U254::from_limbs(<Fr as PrimeField>::MODULUS.0)
+}
+
 impl FieldOps for U254 {
 
     const BITS: usize = 254;
@@ -292,7 +326,11 @@ impl FieldOps for U254 {
 
     #[inline]
     fn mul_mod(self, rhs: Self, m: Self) -> Self {
-        <U254>::mul_mod(self, rhs, m)
+        if m == bn254_prime {
+            mul_bn254_u254(self, rhs)
+        } else {
+            <U254>::mul_mod(self, rhs, m)
+        }
     }
 
     #[inline]
@@ -812,6 +850,7 @@ impl<T: FieldOps> FieldOperations for &Field<T> {
 #[cfg(test)]
 mod tests {
     use crate::field::{Field, U64, FieldOperations, U254, FieldOps, bn254_prime};
+    use crate::graph::Operation;
     use num_traits::One;
     use ruint::aliases::U256;
 
@@ -868,6 +907,126 @@ mod tests {
         let ff = &ff_bn256();
         let result = ff.shr(a, b);
         assert_eq!(want, result);
+    }
+
+    #[test]
+    fn test_bn254_fr_conversion_invariants() {
+        assert_eq!(super::fr_modulus_u254(), bn254_prime);
+        let conversion_values = [
+            U254::ZERO,
+            U254::from(1u64),
+            U254::from(u64::MAX),
+            U254::from(1u64) << 64,
+            (U254::from(1u64) << 64) + U254::from(1u64),
+            U254::from(1u64) << 128,
+            U254::from(1u64) << 192,
+            bn254_prime - U254::from(2u64),
+            bn254_prime - U254::from(1u64),
+        ];
+
+        for value in conversion_values {
+            assert_eq!(
+                super::fr_to_u254(super::u254_to_fr_canonical(value)),
+                value,
+                "Fr conversion roundtrip for {value}"
+            );
+        }
+
+        assert!(!super::is_multi_limb_u254(U254::ZERO));
+        assert!(!super::is_multi_limb_u254(U254::from(u64::MAX)));
+        assert!(super::is_multi_limb_u254(U254::from(1u64) << 64));
+        assert!(super::is_multi_limb_u254(bn254_prime - U254::from(1u64)));
+    }
+
+    #[test]
+    fn test_bn254_mul_fast_path_matches_ruint() {
+        let ff = &ff_bn256();
+        let half = bn254_prime >> 1;
+        let edge_values = [
+            U254::ZERO,
+            U254::from(1u64),
+            U254::from(2u64),
+            U254::from(u64::MAX),
+            U254::from(1u64) << 64,
+            (U254::from(1u64) << 64) + U254::from(1u64),
+            U254::from(1u64) << 128,
+            U254::from(1u64) << 192,
+            half - U254::from(1u64),
+            half,
+            half + U254::from(1u64),
+            bn254_prime - U254::from(2u64),
+            bn254_prime - U254::from(1u64),
+            bn254_prime,
+            bn254_prime + U254::from(1u64),
+            U254::from(1u64) << 253,
+            U254::MAX,
+        ];
+
+        for a in edge_values {
+            for b in edge_values {
+                assert_bn254_mul_matches_ruint(ff, a, b);
+            }
+        }
+
+        let cases = [
+            (U254::ZERO, U254::ZERO),
+            (U254::from(2u64), U254::from(3u64)),
+            (bn254_prime - U254::from(1u64), bn254_prime - U254::from(1u64)),
+            (bn254_prime, bn254_prime + U254::from(1u64)),
+            (U254::MAX, bn254_prime - U254::from(1u64)),
+            (
+                u254("18583076334226168172367231819260574371431472897769128993835383390508861945746"),
+                u254("2805997381032117399116049231308848744608941055401984107726204241709819608479"),
+            ),
+        ];
+
+        for (a, b) in cases {
+            assert_bn254_mul_matches_ruint(ff, a, b);
+        }
+
+        let mut state = 0x9e3779b97f4a7c15u64;
+        for _ in 0..256 {
+            let a = next_test_u254(&mut state) % bn254_prime;
+            let b = next_test_u254(&mut state) % bn254_prime;
+            assert_bn254_mul_matches_ruint(ff, a, b);
+        }
+
+        for _ in 0..256 {
+            let a = next_test_u254(&mut state);
+            let b = next_test_u254(&mut state);
+            assert_bn254_mul_matches_ruint(ff, a, b);
+        }
+    }
+
+    fn assert_bn254_mul_matches_ruint(ff: &Field<U254>, a: U254, b: U254) {
+        let expected = <U254>::mul_mod(a, b, bn254_prime);
+        assert_eq!(
+            <U254 as FieldOps>::mul_mod(a, b, bn254_prime),
+            expected,
+            "FieldOps::mul_mod({a}, {b})"
+        );
+        assert_eq!(ff.mul(a, b), expected, "FieldOperations::mul({a}, {b})");
+        assert_eq!(
+            ff.op_duo(Operation::Mul, a, b),
+            expected,
+            "FieldOperations::op_duo(Mul, {a}, {b})"
+        );
+    }
+
+    fn next_test_u254(state: &mut u64) -> U254 {
+        U254::from_limbs([
+            next_test_u64(state),
+            next_test_u64(state),
+            next_test_u64(state),
+            next_test_u64(state) & ((1u64 << 62) - 1),
+        ])
+    }
+
+    fn next_test_u64(state: &mut u64) -> u64 {
+        *state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        *state
     }
 
     fn u254(s: &str) -> U254 {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -55,6 +55,7 @@ impl Operation {
                     // division by zero
                     U256::ZERO
                 } else {
+                    // Division stays on the legacy path; inversion dominates.
                     a.mul_mod(b.inv_mod(M).unwrap(), M)
                 }
             },
@@ -87,6 +88,9 @@ impl Operation {
 #[inline]
 fn mul_bn254_u256(a: U256, b: U256) -> U256 {
     debug_assert_eq!(fr_modulus_u256(), M);
+    // Keep this guard mirrored with field.rs::mul_bn254_u254.
+    // Noncanonical values can come from integer-style operations; keep those on
+    // the legacy path. The multi-limb check is only a performance gate.
     if a < M && b < M && is_multi_limb_u256(a) && is_multi_limb_u256(b) {
         fr_to_u256(u256_to_fr_canonical(a) * u256_to_fr_canonical(b))
     } else {
@@ -102,6 +106,7 @@ fn is_multi_limb_u256(v: U256) -> bool {
 
 #[inline]
 fn u256_to_fr_canonical(v: U256) -> Fr {
+    // Caller must ensure the value is canonical for Fr::from_bigint.
     debug_assert!(v < M);
     Fr::from_bigint(BigInt(v.into_limbs())).unwrap()
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1465,7 +1465,10 @@ mod tests {
     use std::ops::{Div};
     use super::*;
     use ruint::{uint};
-    use crate::field::U254;
+    use crate::field::{bn254_prime, U254};
+    use crate::{calc_witness, wtns_from_u256_witness};
+    use crate::storage::serialize_witnesscalc_graph;
+    use crate::vm2;
 
     #[test]
     fn test_bn254_graph_fr_conversion_invariants() {
@@ -1602,6 +1605,108 @@ mod tests {
             .wrapping_mul(6364136223846793005)
             .wrapping_add(1442695040888963407);
         *state
+    }
+
+    #[test]
+    fn test_mixed_operations_keep_legacy_mul_semantics() {
+        let canonical = U256::from(17u64);
+        let other = U256::from(23u64);
+        let noncanonical = M + U256::from(5u64);
+        let wide = uint!(69475253542389717254142591005212744711961990799384338423674550404747877783961_U256);
+
+        let bitwise = Operation::Bor.eval(canonical, wide);
+        assert_eq!(
+            Operation::Mul.eval(bitwise, other),
+            bitwise.mul_mod(other, M),
+            "bitwise output feeds multiplication"
+        );
+
+        let shifted = Operation::Shl.eval(U256::from(1u64), U256::from(253u64));
+        assert_eq!(
+            Operation::Mul.eval(shifted, other),
+            shifted.mul_mod(other, M),
+            "shift output feeds multiplication"
+        );
+
+        let modulo = Operation::Mod.eval(noncanonical, U256::from(19u64));
+        assert_eq!(
+            Operation::Mul.eval(modulo, other),
+            modulo.mul_mod(other, M),
+            "mod output feeds multiplication"
+        );
+
+        let idiv = Operation::Idiv.eval(noncanonical, U256::from(3u64));
+        assert_eq!(
+            Operation::Mul.eval(idiv, other),
+            idiv.mul_mod(other, M),
+            "idiv output feeds multiplication"
+        );
+
+        let mul = Operation::Mul.eval(M - U256::from(1u64), M - U256::from(1u64));
+        assert_eq!(mul, U256::from(1u64));
+        assert_eq!(Operation::Eq.eval(mul, U256::from(1u64)), U256::from(1u64));
+        assert_eq!(Operation::Lt.eval(mul, other), U256::from(1u64));
+
+        assert_eq!(Operation::Eq.eval(noncanonical, U256::from(5u64)), U256::ZERO);
+        assert_eq!(Operation::Neq.eval(noncanonical, U256::from(5u64)), U256::from(1u64));
+        assert_eq!(Operation::Gt.eval(noncanonical, other), u_gt(&noncanonical, &other));
+        assert_eq!(Operation::Band.eval(noncanonical, wide), noncanonical.bitand(wide));
+    }
+
+    #[test]
+    fn test_mixed_mul_graph_witness_bytes_match_legacy_values() {
+        let mut nodes = Nodes::new(bn254_prime, "bn128", VecNodes::new());
+        let a = nodes.push_noopt(Node::Input(1)).0;
+        let b = nodes.push_noopt(Node::Input(2)).0;
+        let prime = nodes.const_node_idx_from_value(bn254_prime);
+        let three = nodes.const_node_idx_from_value(U254::from(3u64));
+
+        let bitwise = nodes.push_noopt(Node::Op(Operation::Band, prime, prime)).0;
+        let bitwise_mul = nodes.push_noopt(Node::Op(Operation::Mul, bitwise, three)).0;
+        let bitwise_square = nodes.push_noopt(Node::Op(Operation::Mul, bitwise, bitwise)).0;
+        let shift = nodes.push_noopt(Node::Op(Operation::Shl, a, three)).0;
+        let shift_mul = nodes.push_noopt(Node::Op(Operation::Mul, shift, b)).0;
+        let mul = nodes.push_noopt(Node::Op(Operation::Mul, a, b)).0;
+        let cmp = nodes.push_noopt(Node::Op(Operation::Gt, mul, b)).0;
+        let eq = nodes.push_noopt(Node::Op(Operation::Eq, bitwise, a)).0;
+        let witness_signals = vec![bitwise_mul, bitwise_square, shift_mul, cmp, eq];
+
+        let input_infos = vec![vm2::InputInfo {
+            name: "in".to_string(),
+            offset: 1,
+            lengths: vec![2],
+            type_id: None,
+        }];
+        let types = vec![];
+        let mut graph_data = Vec::new();
+        serialize_witnesscalc_graph(
+            &mut graph_data,
+            &nodes,
+            &witness_signals,
+            &input_infos,
+            &types)
+            .unwrap();
+
+        let actual = calc_witness(r#"{"in":["5","7"]}"#, &graph_data).unwrap();
+
+        let a = U256::from(5u64);
+        let b = U256::from(7u64);
+        let three = U256::from(3u64);
+        let bitwise = u254_to_u256(bn254_prime);
+        let bitwise_mul = bitwise.mul_mod(three, M);
+        let bitwise_square = bitwise.mul_mod(bitwise, M);
+        let shift = Operation::Shl.eval(a, three);
+        let shift_mul = shift.mul_mod(b, M);
+        let mul = a.mul_mod(b, M);
+        let cmp = Operation::Gt.eval(mul, b);
+        let eq = Operation::Eq.eval(bitwise, a);
+        let expected = wtns_from_u256_witness(vec![bitwise_mul, bitwise_square, shift_mul, cmp, eq]);
+
+        assert_eq!(actual, expected);
+    }
+
+    fn u254_to_u256(value: U254) -> U256 {
+        U256::from_limbs(value.into_limbs())
     }
 
     #[test]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -7,6 +7,8 @@ use std::fs::File;
 use std::ops::{BitOr, BitXor, Not};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
+use ark_bn254::Fr;
+use ark_ff::{BigInt, PrimeField};
 use crate::field::{Field, FieldOperations, FieldOps, M};
 use rand::{RngCore};
 use ruint::aliases::U256;
@@ -45,7 +47,7 @@ impl Operation {
     pub fn eval(&self, a: U256, b: U256) -> U256 {
         use Operation::*;
         match self {
-            Mul => a.mul_mod(b, M),
+            Mul => mul_bn254_u256(a, b),
             Div => {
                 if b == U256::ZERO {
                     // as we are simulating a circuit execution with signals
@@ -80,6 +82,38 @@ impl Operation {
             Idiv => if b == U256::ZERO { U256::ZERO } else { a / b },
         }
     }
+}
+
+#[inline]
+fn mul_bn254_u256(a: U256, b: U256) -> U256 {
+    debug_assert_eq!(fr_modulus_u256(), M);
+    if a < M && b < M && is_multi_limb_u256(a) && is_multi_limb_u256(b) {
+        fr_to_u256(u256_to_fr_canonical(a) * u256_to_fr_canonical(b))
+    } else {
+        a.mul_mod(b, M)
+    }
+}
+
+#[inline]
+fn is_multi_limb_u256(v: U256) -> bool {
+    let limbs = v.into_limbs();
+    limbs[1] != 0 || limbs[2] != 0 || limbs[3] != 0
+}
+
+#[inline]
+fn u256_to_fr_canonical(v: U256) -> Fr {
+    debug_assert!(v < M);
+    Fr::from_bigint(BigInt(v.into_limbs())).unwrap()
+}
+
+#[inline]
+fn fr_to_u256(v: Fr) -> U256 {
+    U256::from_limbs(v.into_bigint().0)
+}
+
+#[inline]
+fn fr_modulus_u256() -> U256 {
+    U256::from_limbs(<Fr as PrimeField>::MODULUS.0)
 }
 
 impl From<&Operation> for crate::proto::DuoOp {
@@ -1434,6 +1468,35 @@ mod tests {
     use crate::field::U254;
 
     #[test]
+    fn test_bn254_graph_fr_conversion_invariants() {
+        assert_eq!(fr_modulus_u256(), M);
+        let conversion_values = [
+            U256::ZERO,
+            U256::from(1u64),
+            U256::from(u64::MAX),
+            U256::from(1u64) << 64,
+            (U256::from(1u64) << 64) + U256::from(1u64),
+            U256::from(1u64) << 128,
+            U256::from(1u64) << 192,
+            M - U256::from(2u64),
+            M - U256::from(1u64),
+        ];
+
+        for value in conversion_values {
+            assert_eq!(
+                fr_to_u256(u256_to_fr_canonical(value)),
+                value,
+                "Fr conversion roundtrip for {value}"
+            );
+        }
+
+        assert!(!is_multi_limb_u256(U256::ZERO));
+        assert!(!is_multi_limb_u256(U256::from(u64::MAX)));
+        assert!(is_multi_limb_u256(U256::from(1u64) << 64));
+        assert!(is_multi_limb_u256(M - U256::from(1u64)));
+    }
+
+    #[test]
     fn test_ok() {
         let prime = U254::from_str_radix(
             "21888242871839275222246405745257275088548364400416034343698204186575808495617",
@@ -1444,6 +1507,101 @@ mod tests {
         // println!("{}", rnd::<U254>());
         // let y = rng.gen::<[u8; 3]>();
         println!("{:?}", y);
+    }
+
+    #[test]
+    fn test_mul_matches_u256_modular_multiplication() {
+        let half = M >> 1;
+        let edge_values = [
+            U256::ZERO,
+            U256::from(1u64),
+            U256::from(2u64),
+            U256::from(u64::MAX),
+            U256::from(1u64) << 64,
+            (U256::from(1u64) << 64) + U256::from(1u64),
+            U256::from(1u64) << 128,
+            U256::from(1u64) << 192,
+            half - U256::from(1u64),
+            half,
+            half + U256::from(1u64),
+            M - U256::from(2u64),
+            M - U256::from(1u64),
+            M,
+            M + U256::from(1u64),
+            U256::from(1u64) << 253,
+            (U256::from(1u64) << 254) - U256::from(1u64),
+            U256::MAX,
+        ];
+
+        for a in edge_values {
+            for b in edge_values {
+                assert_mul_matches_u256_modular_multiplication(a, b);
+            }
+        }
+
+        let cases = [
+            (U256::ZERO, U256::ZERO),
+            (U256::from(2u64), U256::from(3u64)),
+            (M - U256::from(1u64), M - U256::from(1u64)),
+            (M, M + U256::from(1u64)),
+            (U256::MAX, M - U256::from(1u64)),
+            (
+                uint!(18583076334226168172367231819260574371431472897769128993835383390508861945746_U256),
+                uint!(69475253542389717254142591005212744711961990799384338423674550404747877783961_U256),
+            ),
+        ];
+
+        for (a, b) in cases {
+            assert_mul_matches_u256_modular_multiplication(a, b);
+        }
+
+        let mut state = 0x9e3779b97f4a7c15u64;
+        for _ in 0..256 {
+            let a = U256::from_limbs([
+                next_test_u64(&mut state),
+                next_test_u64(&mut state),
+                next_test_u64(&mut state),
+                next_test_u64(&mut state),
+            ]) % M;
+            let b = U256::from_limbs([
+                next_test_u64(&mut state),
+                next_test_u64(&mut state),
+                next_test_u64(&mut state),
+                next_test_u64(&mut state),
+            ]) % M;
+            assert_mul_matches_u256_modular_multiplication(a, b);
+        }
+
+        for _ in 0..256 {
+            let a = U256::from_limbs([
+                next_test_u64(&mut state),
+                next_test_u64(&mut state),
+                next_test_u64(&mut state),
+                next_test_u64(&mut state),
+            ]);
+            let b = U256::from_limbs([
+                next_test_u64(&mut state),
+                next_test_u64(&mut state),
+                next_test_u64(&mut state),
+                next_test_u64(&mut state),
+            ]);
+            assert_mul_matches_u256_modular_multiplication(a, b);
+        }
+    }
+
+    fn assert_mul_matches_u256_modular_multiplication(a: U256, b: U256) {
+        assert_eq!(
+            Operation::Mul.eval(a, b),
+            a.mul_mod(b, M),
+            "Operation::Mul.eval({a}, {b})"
+        );
+    }
+
+    fn next_test_u64(state: &mut u64) -> u64 {
+        *state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        *state
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Witness generation spends much of its hot loop multiplying field elements modulo the bn254 scalar prime, and those multiplications go through ruint's `mul_mod`, whose reduction is general over arbitrary moduli. For the single modulus that matters here, a Montgomery multiply specialized to bn254 is meaningfully faster, and arkworks already provides one through `ark_bn254::Fr` (with `ark-ff` compiled using its `asm` feature). This routes canonical wide multiplications through that path and leaves every other operand on ruint. arkworks is already a dependency, so the change stays local to the two multiplication entry points.

Witness output does not change. Both paths return the canonical representative of `(a * b) mod prime`, and the round trip through `Fr` is exact on `[0, prime)`, so results stay byte-for-byte identical. The `< prime` guard is what keeps this sound: it holds non-reduced inputs back from the `Fr` conversion, which is defined only on canonical values, and it confines the bn254-specific `Fr` to its own modulus.

## Changes

- Add a guarded bn254 multiply fast path to both entry points: `impl FieldOps for U254` (the graph evaluator) and `Operation::Mul.eval` over `U256` (the vm interpreter). It engages only when both operands are reduced (`< prime`) and at least `2^64`; small operands and the non-reduced values that bitwise and shift operations can produce stay on ruint's `mul_mod`.
- Treat the multi-limb threshold as a performance gate rather than a correctness one, since ruint is cheaper on small operands and `Fr` is correct for any canonical operand, so routing never changes a result.
- Keep the two parallel copies in step and cross-referenced in comments.

## Compatibility

Public API, the on-disk witness format, and witness output are unchanged for every input. No new dependencies and no `unsafe` are introduced.

## Validation

- Differential tests assert the fast path equals ruint `mul_mod` across boundary values (`0`, `1`, `prime - 1`, `prime`, `prime + 1`, half-modulus, `2^253`, `2^254 - 1`, `U::MAX`) and across random canonical and full-range operands, exercised through `FieldOps::mul_mod`, `FieldOperations::mul`, and `op_duo`.
- A graph-level test drives `calc_witness` on a mixed circuit (bitwise, shift, mod, and idiv outputs feeding multiplication; multiplication feeding comparisons; noncanonical operands) and compares the output bytes against legacy values, requiring byte-for-byte witness equality.
- `cargo test --workspace --locked` and `cargo test --release --locked` pass.
- Benchmarks (release profile, locked dependencies, warmup, 25 batches, median): a pure-multiply graph chain runs about 24% faster (68.9 to 52.2 ns per node at 100k nodes), and a single canonical-wide multiply about 28% faster (58.7 to 42.0 ns per op). An unchanged raw `mul_mod` control measures identically on both versions, confirming the delta comes from the changed code. Operands below `2^64` or at or above the prime pay a few nanoseconds of guard overhead on the unchanged path.
