### PR TITLE
fix(artifact): return errors for malformed graph artifacts

### DIFF
--- a/include/graph_witness.h
+++ b/include/graph_witness.h
@@ -18,7 +18,7 @@ int
 gw_calc_witness(const char *inputs,
 				const void *graph_data, const size_t graph_data_len,
 			    void **wtns_data, size_t *wtns_len,
-				const gw_status_t *status);
+				gw_status_t *status);
 
 void
 gw_free_status(gw_status_t *status) {

--- a/src/field.rs
+++ b/src/field.rs
@@ -594,6 +594,9 @@ impl<T: FieldOps> FieldOperations for &Field<T> {
 
     #[inline]
     fn modulo(&self, lhs: Self::Type, rhs: Self::Type) -> Self::Type {
+        if rhs == T::zero() {
+            return T::zero();
+        }
         lhs % rhs
     }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -982,7 +982,7 @@ fn invalid_graph(msg: String) -> std::io::Error {
 /// Graph artifacts are untrusted, so a malformed index must surface as an
 /// error here rather than an out-of-bounds panic inside [`evaluate`], whose
 /// hot loop indexes these values directly.
-pub fn validate_node_indices<NS: NodesStorage>(
+pub(crate) fn validate_node_indices<NS: NodesStorage>(
     nodes: &NS, num_inputs: usize, num_constants: usize,
     outputs: &[usize]) -> std::io::Result<()> {
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -973,11 +973,85 @@ pub fn optimize<T: FieldOps + 'static, NS: NodesStorage + 'static>(
     tree_shake(nodes, outputs);
 }
 
+fn invalid_graph(msg: String) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, msg)
+}
+
+/// Verify that every decoded node references only earlier nodes, an in-range
+/// input, and an existing constant, and that every requested output exists.
+/// Graph artifacts are untrusted, so a malformed index must surface as an
+/// error here rather than an out-of-bounds panic inside [`evaluate`], whose
+/// hot loop indexes these values directly.
+pub fn validate_node_indices<NS: NodesStorage>(
+    nodes: &NS, num_inputs: usize, num_constants: usize,
+    outputs: &[usize]) -> std::io::Result<()> {
+
+    let node_count = nodes.len();
+    for i in 0..node_count {
+        let node = nodes.get(i)
+            .ok_or_else(|| invalid_graph(format!("Graph node {} is missing", i)))?;
+        match node {
+            Node::Unknown => {
+                return Err(invalid_graph(format!("Graph node {} has unknown type", i)));
+            }
+            Node::Input(idx) => {
+                if idx >= num_inputs {
+                    return Err(invalid_graph(format!(
+                        "Graph node {} reads input {} but only {} inputs exist",
+                        i, idx, num_inputs)));
+                }
+            }
+            Node::Constant(idx) => {
+                if idx >= num_constants {
+                    return Err(invalid_graph(format!(
+                        "Graph node {} reads constant {} but only {} constants exist",
+                        i, idx, num_constants)));
+                }
+            }
+            // Operands must reference earlier nodes: the graph is stored in
+            // evaluation order, so a node may only depend on those already
+            // computed (index strictly below its own position).
+            Node::UnoOp(_, a) => check_operand(i, a)?,
+            Node::Op(_, a, b) => {
+                check_operand(i, a)?;
+                check_operand(i, b)?;
+            }
+            Node::TresOp(_, a, b, c) => {
+                check_operand(i, a)?;
+                check_operand(i, b)?;
+                check_operand(i, c)?;
+            }
+        }
+    }
+
+    for &out in outputs {
+        if out >= node_count {
+            return Err(invalid_graph(format!(
+                "Graph output references node {} but only {} nodes exist",
+                out, node_count)));
+        }
+    }
+
+    Ok(())
+}
+
+fn check_operand(node: usize, operand: usize) -> std::io::Result<()> {
+    if operand >= node {
+        return Err(invalid_graph(format!(
+            "Graph node {} references operand {} at or after its own position",
+            node, operand)));
+    }
+    Ok(())
+}
+
 pub fn evaluate<T: FieldOps, F: FieldOperations<Type = T>, NS: NodesStorage>(
     ff: F, nodes: &NS, inputs: &[T], outputs: &[usize],
     constants: &[T]) -> Vec<T>
 where Vec<T>: FromIterator<<F as FieldOperations>::Type>
 {
+    // Indices are validated by validate_node_indices before evaluation; see
+    // calc_witness_typed. evaluate itself assumes that invariant and indexes
+    // inputs, constants, and prior values directly.
     // assert_valid(nodes);
 
     let start = Instant::now();
@@ -1432,6 +1506,48 @@ mod tests {
     use super::*;
     use ruint::{uint};
     use crate::field::U254;
+
+    #[test]
+    fn test_validate_node_indices_accepts_valid_graph() {
+        let mut nodes = VecNodes::new();
+        nodes.push(Node::Input(0));
+        nodes.push(Node::Op(Operation::Mul, 0, 0));
+        validate_node_indices(&nodes, 1, 0, &[1]).unwrap();
+    }
+
+    #[test]
+    fn test_validate_node_indices_rejects_out_of_range_input() {
+        let mut nodes = VecNodes::new();
+        nodes.push(Node::Input(5));
+        let err = validate_node_indices(&nodes, 1, 0, &[]).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_validate_node_indices_rejects_forward_operand() {
+        let mut nodes = VecNodes::new();
+        nodes.push(Node::Input(0));
+        // Operand b references node 5, which is not below this node's position.
+        nodes.push(Node::Op(Operation::Mul, 0, 5));
+        let err = validate_node_indices(&nodes, 1, 0, &[]).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_validate_node_indices_rejects_out_of_range_output() {
+        let mut nodes = VecNodes::new();
+        nodes.push(Node::Input(0));
+        let err = validate_node_indices(&nodes, 1, 0, &[7]).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_validate_node_indices_rejects_unknown_node() {
+        let mut nodes = VecNodes::new();
+        nodes.push(Node::Unknown);
+        let err = validate_node_indices(&nodes, 0, 0, &[]).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
 
     #[test]
     fn test_ok() {

--- a/src/graph_inputs.rs
+++ b/src/graph_inputs.rs
@@ -1,0 +1,250 @@
+use std::collections::HashMap;
+use std::io::Cursor;
+
+use anyhow::anyhow;
+
+use crate::field::{Field, FieldOps};
+use crate::vm2::Component;
+use crate::vm2_setup::init_signals;
+use crate::{vm2, InputSignalsInfo, MAX_GRAPH_V2_INPUT_SIGNALS};
+
+pub(super) fn init_inputs_from_inputs_mapping<T: FieldOps>(
+    input_list: &HashMap<String, Vec<T>>,
+    inputs_info: &InputSignalsInfo,
+) -> Result<Vec<T>, Box<dyn std::error::Error>> {
+    let mut inputs_len: usize = 1;
+    for (offset, len) in inputs_info.values() {
+        let idx = checked_input_add(*offset, *len, "offset plus length")?;
+        if idx > inputs_len {
+            inputs_len = idx;
+        }
+    }
+    let mut inputs = try_reserve_input_vec(inputs_len, "V1 inputs")?;
+    inputs.resize(inputs_len, T::zero());
+    inputs[0] = T::one();
+    let mut inputs_filled = 1;
+    for (key, value) in input_list {
+        match inputs_info.get(key) {
+            None => {
+                return Err(anyhow!("Invalid input signal name for the circuit: {}", key).into());
+            }
+            Some(&(offset, len)) => {
+                if len != value.len() {
+                    return Err(anyhow!("Invalid input signal {} length: {}", key, len).into());
+                }
+                for (i, v) in value.iter().enumerate() {
+                    inputs[offset + i] = *v;
+                    inputs_filled += 1;
+                }
+            }
+        }
+    }
+
+    if inputs_filled != inputs_len {
+        return Err(anyhow!(
+            "Invalid input signal count: {}, expected {}",
+            inputs_filled,
+            inputs_len
+        )
+        .into());
+    }
+
+    Ok(inputs)
+}
+
+pub(super) fn init_inputs_from_v2<T: FieldOps>(
+    inputs_json: &str,
+    ff: &Field<T>,
+    input_info: &[vm2::InputInfo],
+    types: &[vm2::Type],
+) -> Result<Vec<T>, Box<dyn std::error::Error>> {
+    let (inputs_size, min_offset) = checked_v2_input_layout(input_info, types)?;
+    checked_component_input_count(inputs_size)?;
+    let shifted_input_info = shift_input_offsets(input_info, min_offset)?;
+    let mut component = Component::new(0, 0, vec![], inputs_size, inputs_size);
+    let inputs_cursor = Cursor::new(inputs_json.as_bytes());
+    init_signals(
+        inputs_cursor,
+        ff,
+        types,
+        &shifted_input_info,
+        &mut component,
+    )?;
+    let mut component_signals = try_reserve_input_vec(inputs_size, "V2 component output")?;
+    component.write_all_signals(&mut component_signals);
+
+    let inputs_capacity = checked_input_add(inputs_size, 1, "inputs size plus one")?;
+    let mut inputs = try_reserve_input_vec(inputs_capacity, "V2 inputs")?;
+    inputs.push(T::one());
+    inputs.extend(
+        component_signals
+            .iter()
+            .take(inputs_size)
+            .map(|x| x.expect("[assertion] init_signals should not allow None input signals")),
+    );
+
+    Ok(inputs)
+}
+
+fn checked_v2_input_layout(
+    input_info: &[vm2::InputInfo],
+    types: &[vm2::Type],
+) -> Result<(usize, usize), Box<dyn std::error::Error>> {
+    let mut inputs_size = 0usize;
+    let mut ranges = try_reserve_input_vec(input_info.len(), "V2 input ranges")?;
+    for info in input_info {
+        let base_type_size = match &info.type_id {
+            None => 1,
+            Some(type_id) => {
+                let type_idx = types
+                    .iter()
+                    .position(|ty| &ty.name == type_id)
+                    .ok_or_else(|| invalid_input_metadata("Unknown input type"))?;
+                checked_type_size_by_index(type_idx, types, &mut Vec::new())?
+            }
+        };
+        let array_count = checked_product(&info.lengths, "input dimensions")?;
+        let input_size = checked_input_mul(array_count, base_type_size, "input size")?;
+        if input_size == 0 {
+            return Err(invalid_input_metadata(
+                "Input metadata size must be nonzero",
+            ));
+        }
+        inputs_size = checked_input_add(inputs_size, input_size, "total input size")?;
+        let end = checked_input_add(info.offset, input_size, "input offset plus size")?;
+        ranges.push((info.offset, end));
+    }
+
+    ranges.sort_by_key(|(offset, _)| *offset);
+    let min_offset = ranges.first().map(|(offset, _)| *offset).unwrap_or(0);
+    let mut expected_offset = min_offset;
+    for (offset, end) in ranges {
+        if offset != expected_offset {
+            return Err(invalid_input_metadata(
+                "Input metadata offsets must be contiguous and non-overlapping",
+            ));
+        }
+        expected_offset = end;
+    }
+    let signals_num = checked_input_add(min_offset, inputs_size, "signal count")?;
+    if expected_offset != signals_num {
+        return Err(invalid_input_metadata(
+            "Input metadata span is inconsistent",
+        ));
+    }
+    Ok((inputs_size, min_offset))
+}
+
+fn shift_input_offsets(
+    input_info: &[vm2::InputInfo],
+    min_offset: usize,
+) -> Result<Vec<vm2::InputInfo>, Box<dyn std::error::Error>> {
+    let mut shifted = try_reserve_input_vec(input_info.len(), "V2 shifted input info")?;
+    for info in input_info {
+        let mut shifted_info = info.clone();
+        shifted_info.offset = info.offset.checked_sub(min_offset).ok_or_else(|| {
+            invalid_input_metadata("Input metadata offset is below minimum offset")
+        })?;
+        shifted.push(shifted_info);
+    }
+    Ok(shifted)
+}
+
+fn checked_component_input_count(signals_num: usize) -> Result<(), Box<dyn std::error::Error>> {
+    if signals_num > MAX_GRAPH_V2_INPUT_SIGNALS {
+        return Err(invalid_input_metadata(
+            "Input metadata V2 input count is too large",
+        ));
+    }
+    Ok(())
+}
+
+fn checked_type_size_by_index(
+    type_idx: usize,
+    types: &[vm2::Type],
+    visiting: &mut Vec<usize>,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    if type_idx >= types.len() {
+        return Err(invalid_input_metadata("Bus type index is out of range"));
+    }
+    if visiting.contains(&type_idx) {
+        return Err(invalid_input_metadata("Bus type metadata contains a cycle"));
+    }
+
+    visiting.push(type_idx);
+    let ty = &types[type_idx];
+    let mut total_size = 0usize;
+    for field in &ty.fields {
+        let base_type_size = checked_field_base_size(field, types, visiting)?;
+        if field.base_type_size != base_type_size {
+            return Err(invalid_input_metadata(
+                "Input metadata base_type_size is inconsistent with field type",
+            ));
+        }
+
+        let field_size = if field.dims.is_empty() {
+            base_type_size
+        } else {
+            let dim_product = checked_product(&field.dims, "type field dimensions")?;
+            checked_input_mul(base_type_size, dim_product, "type field size")?
+        };
+        total_size = checked_input_add(total_size, field_size, "type size")?;
+    }
+    visiting.pop();
+    Ok(total_size)
+}
+
+fn checked_field_base_size(
+    field: &vm2::TypeField,
+    types: &[vm2::Type],
+    visiting: &mut Vec<usize>,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    match &field.kind {
+        vm2::TypeFieldKind::Ff => Ok(1),
+        vm2::TypeFieldKind::Bus(bus_idx) => checked_type_size_by_index(*bus_idx, types, visiting),
+    }
+}
+
+fn checked_product(values: &[usize], context: &str) -> Result<usize, Box<dyn std::error::Error>> {
+    values
+        .iter()
+        .try_fold(1usize, |acc, value| checked_input_mul(acc, *value, context))
+}
+
+fn checked_input_add(
+    lhs: usize,
+    rhs: usize,
+    context: &str,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    lhs.checked_add(rhs).ok_or_else(|| {
+        invalid_input_metadata(format!("Input metadata {} overflows usize", context))
+    })
+}
+
+fn checked_input_mul(
+    lhs: usize,
+    rhs: usize,
+    context: &str,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    lhs.checked_mul(rhs).ok_or_else(|| {
+        invalid_input_metadata(format!("Input metadata {} overflows usize", context))
+    })
+}
+
+fn try_reserve_input_vec<T>(
+    len: usize,
+    context: &str,
+) -> Result<Vec<T>, Box<dyn std::error::Error>> {
+    let mut vec = Vec::new();
+    vec.try_reserve(len).map_err(|_| {
+        invalid_input_metadata(format!(
+            "Input metadata {} exceeds available memory",
+            context
+        ))
+    })?;
+    Ok(vec)
+}
+
+fn invalid_input_metadata(message: impl Into<String>) -> Box<dyn std::error::Error> {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, message.into()).into()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ fn calc_witness_graph(
 
     let start = std::time::Instant::now();
     let (nodes, signals, input_info): (Box<dyn NodesInterface>, Vec<usize>, InputInfo) =
-        deserialize_witnesscalc_graph_from_bytes(graph_data).unwrap();
+        deserialize_witnesscalc_graph_from_bytes(graph_data)?;
     println!("Graph loaded in {:?}", start.elapsed());
 
     let start = std::time::Instant::now();
@@ -573,11 +573,13 @@ fn witness<T: FieldOps>(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::panic;
     use prost::Message;
     use ruint::aliases::U256;
     use ruint::uint;
     use crate::proto::InputNode;
     use crate::field::{Field, U254, bn254_prime};
+    use crate::storage::WITNESSCALC_GRAPH_MAGIC_002;
 
     #[test]
     fn test_ok() {
@@ -629,5 +631,14 @@ mod tests {
             U254::from(2),
             U254::from(3)]);
         assert_eq!(res, want);
+    }
+
+    #[test]
+    fn test_calc_witness_returns_error_for_truncated_graph_artifact() {
+        let bytes = WITNESSCALC_GRAPH_MAGIC_002.to_vec();
+        let result = panic::catch_unwind(|| super::calc_witness("{}", &bytes));
+
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use std::slice::from_raw_parts;
 use anyhow::anyhow;
 use ruint::aliases::U256;
 use ruint::ParseError;
-use crate::graph::{evaluate, Nodes, NodesInterface, NodesStorage, VecNodes};
+use crate::graph::{evaluate, validate_node_indices, Nodes, NodesInterface, NodesStorage, VecNodes};
 use wtns_file::FieldElement;
 use ark_bn254::Fr;
 use ark_ff::{BigInteger, PrimeField};
@@ -225,6 +225,9 @@ fn calc_witness_typed<T: FieldOps, NS: NodesStorage>(
             init_inputs_from_v2(inputs, &nodes.ff, input_info, types)?
         }
     };
+
+    validate_node_indices(
+        &nodes.nodes, inputs.len(), nodes.constants.len(), signals)?;
 
     let result = evaluate(
         &nodes.ff, &nodes.nodes, &inputs, signals, &nodes.constants);
@@ -639,6 +642,25 @@ mod tests {
         let result = panic::catch_unwind(|| super::calc_witness("{}", &bytes));
 
         assert!(result.is_ok());
+        assert!(result.unwrap().is_err());
+    }
+
+    #[test]
+    fn test_calc_witness_rejects_out_of_range_node_index() {
+        use crate::graph::{Node, Nodes, NodesInterface, Operation, VecNodes};
+        use crate::storage::serialize_witnesscalc_graph;
+
+        // A graph that decodes cleanly but whose second node references a
+        // non-existent operand must produce an error, not a panic.
+        let mut nodes = Nodes::new(bn254_prime, "bn128", VecNodes::new());
+        nodes.push_noopt(Node::Input(0));
+        nodes.push_noopt(Node::Op(Operation::Mul, 0, 5));
+
+        let mut bytes = Vec::new();
+        serialize_witnesscalc_graph(&mut bytes, &nodes, &[1], &[], &[]).unwrap();
+
+        let result = panic::catch_unwind(|| super::calc_witness("{}", &bytes));
+        assert!(result.is_ok(), "calc_witness must not panic");
         assert!(result.unwrap().is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(non_snake_case)]
 // #[allow(dead_code)]
 pub mod field;
+mod graph_inputs;
 pub mod graph;
 pub mod storage;
 pub mod vm;
@@ -14,11 +15,11 @@ pub mod parser;
 
 use std::collections::HashMap;
 use std::ffi::{c_char, c_int, c_void, CStr};
-use std::io::Cursor;
 use std::slice::from_raw_parts;
 use anyhow::anyhow;
 use ruint::aliases::U256;
 use ruint::ParseError;
+use crate::graph_inputs::{init_inputs_from_inputs_mapping, init_inputs_from_v2};
 use crate::graph::{evaluate, validate_node_indices, Nodes, NodesInterface, NodesStorage, VecNodes};
 use wtns_file::FieldElement;
 use ark_bn254::Fr;
@@ -27,7 +28,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use crate::field::{bn254_prime, Field, FieldOperations, FieldOps, U254, U64};
 use crate::storage::proto_deserializer::{deserialize_witnesscalc_graph_from_bytes, InputInfo};
 use crate::storage::{deserialize_witnesscalc_vm2_body, read_witnesscalc_vm2_header, WITNESSCALC_CVM_MAGIC, WITNESSCALC_GRAPH_MAGIC_002, WITNESSCALC_GRAPH_MAGIC_001};
-use crate::vm2::{execute, Circuit, Component};
+use crate::vm2::{execute, Circuit};
 use crate::vm2_setup::{build_component_tree, init_signals};
 
 pub type InputSignalsInfo = HashMap<String, (usize, usize)>;
@@ -236,236 +237,6 @@ fn calc_witness_typed<T: FieldOps, NS: NodesStorage>(
         &nodes.ff, &nodes.nodes, &inputs, signals, &nodes.constants);
 
     Ok(result)
-}
-
-fn init_inputs_from_inputs_mapping<T: FieldOps>(
-    input_list: &HashMap<String, Vec<T>>,
-    inputs_info: &InputSignalsInfo) -> Result<Vec<T>, Box<dyn std::error::Error>> {
-
-    let mut inputs_len: usize = 1;
-    for (offset, len) in inputs_info.values() {
-        let idx = checked_input_add(*offset, *len, "offset plus length")?;
-        if idx > inputs_len {
-            inputs_len = idx;
-        }
-    }
-    let mut inputs = try_reserve_input_vec(inputs_len, "V1 inputs")?;
-    inputs.resize(inputs_len, T::zero());
-    inputs[0] = T::one();
-    let mut inputs_filled = 1;
-    for (key, value) in input_list {
-        match inputs_info.get(key) {
-            None => {
-                return Err(anyhow!("Invalid input signal name for the circuit: {}", key).into());
-            }
-            Some(&(offset, len)) => {
-                if len != value.len() {
-                    return Err(anyhow!("Invalid input signal {} length: {}", key, len).into());
-                }
-                for (i, v) in value.iter().enumerate() {
-                    inputs[offset + i] = *v;
-                    inputs_filled += 1;
-                }
-            }
-        }
-    };
-
-    if inputs_filled != inputs_len {
-        return Err(anyhow!("Invalid input signal count: {}, expected {}", inputs_filled, inputs_len).into());
-    }
-
-    Ok(inputs)
-}
-
-fn init_inputs_from_v2<T: FieldOps>(
-    inputs_json: &str,
-    ff: &Field<T>,
-    input_info: &[vm2::InputInfo],
-    types: &[vm2::Type],
-) -> Result<Vec<T>, Box<dyn std::error::Error>> {
-    let (inputs_size, min_offset) = checked_v2_input_layout(input_info, types)?;
-    checked_component_input_count(inputs_size)?;
-    let shifted_input_info = shift_input_offsets(input_info, min_offset)?;
-    let mut component = Component::new(0, 0, vec![], inputs_size, inputs_size);
-    let inputs_cursor = Cursor::new(inputs_json.as_bytes());
-    init_signals(inputs_cursor, ff, types, &shifted_input_info, &mut component)?;
-    let mut component_signals = try_reserve_input_vec(inputs_size, "V2 component output")?;
-    component.write_all_signals(&mut component_signals);
-
-    let inputs_capacity = checked_input_add(inputs_size, 1, "inputs size plus one")?;
-    let mut inputs = try_reserve_input_vec(inputs_capacity, "V2 inputs")?;
-    inputs.push(T::one());
-    inputs.extend(
-        component_signals.iter()
-            .take(inputs_size)
-            .map(|x| x.expect(
-                "[assertion] init_signals should not allow None input signals")));
-
-    Ok(inputs)
-}
-
-fn checked_v2_input_layout(
-    input_info: &[vm2::InputInfo],
-    types: &[vm2::Type],
-) -> Result<(usize, usize), Box<dyn std::error::Error>> {
-    let mut inputs_size = 0usize;
-    let mut ranges = try_reserve_input_vec(input_info.len(), "V2 input ranges")?;
-    for info in input_info {
-        let base_type_size = match &info.type_id {
-            None => 1,
-            Some(type_id) => {
-                let type_idx = types.iter()
-                    .position(|ty| &ty.name == type_id)
-                    .ok_or_else(|| invalid_input_metadata("Unknown input type"))?;
-                checked_type_size_by_index(type_idx, types, &mut Vec::new())?
-            }
-        };
-        let array_count = checked_product(&info.lengths, "input dimensions")?;
-        let input_size = checked_input_mul(array_count, base_type_size, "input size")?;
-        if input_size == 0 {
-            return Err(invalid_input_metadata("Input metadata size must be nonzero"));
-        }
-        inputs_size = checked_input_add(inputs_size, input_size, "total input size")?;
-        let end = checked_input_add(info.offset, input_size, "input offset plus size")?;
-        ranges.push((info.offset, end));
-    }
-
-    ranges.sort_by_key(|(offset, _)| *offset);
-    let min_offset = ranges.first().map(|(offset, _)| *offset).unwrap_or(0);
-    let mut expected_offset = min_offset;
-    for (offset, end) in ranges {
-        if offset != expected_offset {
-            return Err(invalid_input_metadata(
-                "Input metadata offsets must be contiguous and non-overlapping",
-            ));
-        }
-        expected_offset = end;
-    }
-    let signals_num = checked_input_add(min_offset, inputs_size, "signal count")?;
-    if expected_offset != signals_num {
-        return Err(invalid_input_metadata("Input metadata span is inconsistent"));
-    }
-    Ok((inputs_size, min_offset))
-}
-
-fn shift_input_offsets(
-    input_info: &[vm2::InputInfo],
-    min_offset: usize,
-) -> Result<Vec<vm2::InputInfo>, Box<dyn std::error::Error>> {
-    let mut shifted = try_reserve_input_vec(input_info.len(), "V2 shifted input info")?;
-    for info in input_info {
-        let mut shifted_info = info.clone();
-        shifted_info.offset = info.offset.checked_sub(min_offset).ok_or_else(|| {
-            invalid_input_metadata("Input metadata offset is below minimum offset")
-        })?;
-        shifted.push(shifted_info);
-    }
-    Ok(shifted)
-}
-
-fn checked_component_input_count(
-    signals_num: usize,
-) -> Result<(), Box<dyn std::error::Error>> {
-    if signals_num > MAX_GRAPH_V2_INPUT_SIGNALS {
-        return Err(invalid_input_metadata(
-            "Input metadata V2 input count is too large",
-        ));
-    }
-    Ok(())
-}
-
-fn checked_type_size_by_index(
-    type_idx: usize,
-    types: &[vm2::Type],
-    visiting: &mut Vec<usize>,
-) -> Result<usize, Box<dyn std::error::Error>> {
-    if type_idx >= types.len() {
-        return Err(invalid_input_metadata("Bus type index is out of range"));
-    }
-    if visiting.contains(&type_idx) {
-        return Err(invalid_input_metadata("Bus type metadata contains a cycle"));
-    }
-
-    visiting.push(type_idx);
-    let ty = &types[type_idx];
-    let mut total_size = 0usize;
-    for field in &ty.fields {
-        let base_type_size = checked_field_base_size(field, types, visiting)?;
-        if field.base_type_size != base_type_size {
-            return Err(invalid_input_metadata(
-                "Input metadata base_type_size is inconsistent with field type",
-            ));
-        }
-
-        let field_size = if field.dims.is_empty() {
-            base_type_size
-        } else {
-            let dim_product = checked_product(&field.dims, "type field dimensions")?;
-            checked_input_mul(base_type_size, dim_product, "type field size")?
-        };
-        total_size = checked_input_add(total_size, field_size, "type size")?;
-    }
-    visiting.pop();
-    Ok(total_size)
-}
-
-fn checked_field_base_size(
-    field: &vm2::TypeField,
-    types: &[vm2::Type],
-    visiting: &mut Vec<usize>,
-) -> Result<usize, Box<dyn std::error::Error>> {
-    match &field.kind {
-        vm2::TypeFieldKind::Ff => Ok(1),
-        vm2::TypeFieldKind::Bus(bus_idx) => {
-            checked_type_size_by_index(*bus_idx, types, visiting)
-        }
-    }
-}
-
-fn checked_product(
-    values: &[usize],
-    context: &str,
-) -> Result<usize, Box<dyn std::error::Error>> {
-    values.iter().try_fold(1usize, |acc, value| {
-        checked_input_mul(acc, *value, context)
-    })
-}
-
-fn checked_input_add(
-    lhs: usize,
-    rhs: usize,
-    context: &str,
-) -> Result<usize, Box<dyn std::error::Error>> {
-    lhs.checked_add(rhs).ok_or_else(|| {
-        invalid_input_metadata(format!("Input metadata {} overflows usize", context))
-    })
-}
-
-fn checked_input_mul(
-    lhs: usize,
-    rhs: usize,
-    context: &str,
-) -> Result<usize, Box<dyn std::error::Error>> {
-    lhs.checked_mul(rhs).ok_or_else(|| {
-        invalid_input_metadata(format!("Input metadata {} overflows usize", context))
-    })
-}
-
-fn try_reserve_input_vec<T>(
-    len: usize,
-    context: &str,
-) -> Result<Vec<T>, Box<dyn std::error::Error>> {
-    let mut vec = Vec::new();
-    vec.try_reserve(len).map_err(|_| {
-        invalid_input_metadata(format!(
-            "Input metadata {} exceeds available memory",
-            context))
-    })?;
-    Ok(vec)
-}
-
-fn invalid_input_metadata(message: impl Into<String>) -> Box<dyn std::error::Error> {
-    std::io::Error::new(std::io::ErrorKind::InvalidData, message.into()).into()
 }
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,9 +53,27 @@ fn prepare_status(status: *mut gw_status_t, code: GW_ERROR_CODE, error_msg: &str
         let bs = error_msg.as_bytes();
         unsafe {
             (*status).code = code;
-            (*status).error_msg = libc::malloc(bs.len()+1) as *mut c_char;
-            libc::memcpy((*status).error_msg as *mut c_void, bs.as_ptr() as *mut c_void, bs.len());
-            *((*status).error_msg.add(bs.len())) = 0;
+            (*status).error_msg = std::ptr::null_mut();
+            let error_msg_ptr = libc::malloc(bs.len() + 1) as *mut c_char;
+            if error_msg_ptr.is_null() {
+                return;
+            }
+            libc::memcpy(
+                error_msg_ptr as *mut c_void,
+                bs.as_ptr() as *mut c_void,
+                bs.len(),
+            );
+            *(error_msg_ptr.add(bs.len())) = 0;
+            (*status).error_msg = error_msg_ptr;
+        }
+    }
+}
+
+fn prepare_success_status(status: *mut gw_status_t) {
+    if !status.is_null() {
+        unsafe {
+            (*status).code = GW_ERROR_CODE_OK;
+            (*status).error_msg = std::ptr::null_mut();
         }
     }
 }
@@ -128,7 +146,7 @@ pub unsafe extern "C" fn gw_calc_witness(
         libc::memcpy(*wtns_data, witness_data.as_ptr() as *const c_void, witness_data.len());
     }
 
-    prepare_status(status, GW_ERROR_CODE_ERROR, "test error");
+    prepare_success_status(status);
 
     0
 }
@@ -515,6 +533,8 @@ fn witness<T: FieldOps>(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::ffi::{c_void, CString};
+    use std::ptr;
     use std::panic;
     use prost::Message;
     use ruint::aliases::U256;
@@ -555,6 +575,48 @@ mod tests {
         };
         let v = i.encode_to_vec();
         println!("{:?}", v.len());
+    }
+
+    fn empty_status(code: super::GW_ERROR_CODE) -> super::gw_status_t {
+        super::gw_status_t {
+            code,
+            error_msg: ptr::null_mut(),
+        }
+    }
+
+    #[test]
+    fn ffi_success_sets_ok_status_and_writes_witness() {
+        let inputs = CString::new(include_str!(
+            "../tests/vm2_setup/data/test_init_signals__inputs.json"
+        ))
+        .unwrap();
+        let graph_data = include_bytes!("../tests/vm2_setup/data/test_init_signals__bc2.wcd");
+        let mut wtns_data = ptr::null_mut();
+        let mut wtns_len = 0;
+        let mut status = empty_status(super::GW_ERROR_CODE_ERROR);
+
+        let result = unsafe {
+            super::gw_calc_witness(
+                inputs.as_ptr(),
+                graph_data.as_ptr() as *const c_void,
+                graph_data.len(),
+                &mut wtns_data,
+                &mut wtns_len,
+                &mut status,
+            )
+        };
+
+        assert_eq!(result, 0);
+        assert_eq!(status.code, super::GW_ERROR_CODE_OK);
+        assert!(status.error_msg.is_null());
+        assert!(!wtns_data.is_null());
+        assert!(wtns_len > 0);
+
+        let witness = unsafe { std::slice::from_raw_parts(wtns_data as *const u8, wtns_len) };
+        assert!(witness.starts_with(b"wtns"));
+        unsafe {
+            libc::free(wtns_data);
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,11 +58,13 @@ fn prepare_status(status: *mut gw_status_t, code: GW_ERROR_CODE, error_msg: &str
             if error_msg_ptr.is_null() {
                 return;
             }
-            libc::memcpy(
-                error_msg_ptr as *mut c_void,
-                bs.as_ptr() as *mut c_void,
-                bs.len(),
-            );
+            if !bs.is_empty() {
+                libc::memcpy(
+                    error_msg_ptr as *mut c_void,
+                    bs.as_ptr() as *const c_void,
+                    bs.len(),
+                );
+            }
             *(error_msg_ptr.add(bs.len())) = 0;
             (*status).error_msg = error_msg_ptr;
         }
@@ -533,7 +535,7 @@ fn witness<T: FieldOps>(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::ffi::{c_void, CString};
+    use std::ffi::{c_void, CStr, CString};
     use std::ptr;
     use std::panic;
     use prost::Message;
@@ -581,6 +583,21 @@ mod tests {
         super::gw_status_t {
             code,
             error_msg: ptr::null_mut(),
+        }
+    }
+
+    #[test]
+    fn prepare_status_handles_empty_error_message() {
+        let mut status = empty_status(super::GW_ERROR_CODE_OK);
+
+        super::prepare_status(&mut status, super::GW_ERROR_CODE_ERROR, "");
+
+        assert_eq!(status.code, super::GW_ERROR_CODE_ERROR);
+        assert!(!status.error_msg.is_null());
+        let error_msg = unsafe { CStr::from_ptr(status.error_msg) };
+        assert_eq!(error_msg.to_bytes(), b"");
+        unsafe {
+            libc::free(status.error_msg as *mut c_void);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,10 +314,10 @@ fn checked_v2_input_layout(
         let base_type_size = match &info.type_id {
             None => 1,
             Some(type_id) => {
-                let ty = types.iter()
-                    .find(|ty| &ty.name == type_id)
+                let type_idx = types.iter()
+                    .position(|ty| &ty.name == type_id)
                     .ok_or_else(|| invalid_input_metadata("Unknown input type"))?;
-                checked_type_size(ty, types)?
+                checked_type_size_by_index(type_idx, types, &mut Vec::new())?
             }
         };
         let array_count = checked_product(&info.lengths, "input dimensions")?;
@@ -374,27 +374,52 @@ fn checked_component_input_count(
     Ok(())
 }
 
-fn checked_type_size(
-    ty: &vm2::Type,
+fn checked_type_size_by_index(
+    type_idx: usize,
     types: &[vm2::Type],
+    visiting: &mut Vec<usize>,
 ) -> Result<usize, Box<dyn std::error::Error>> {
+    if type_idx >= types.len() {
+        return Err(invalid_input_metadata("Bus type index is out of range"));
+    }
+    if visiting.contains(&type_idx) {
+        return Err(invalid_input_metadata("Bus type metadata contains a cycle"));
+    }
+
+    visiting.push(type_idx);
+    let ty = &types[type_idx];
     let mut total_size = 0usize;
     for field in &ty.fields {
-        if let vm2::TypeFieldKind::Bus(bus_idx) = &field.kind {
-            if *bus_idx >= types.len() {
-                return Err(invalid_input_metadata("Bus type index is out of range"));
-            }
+        let base_type_size = checked_field_base_size(field, types, visiting)?;
+        if field.base_type_size != base_type_size {
+            return Err(invalid_input_metadata(
+                "Input metadata base_type_size is inconsistent with field type",
+            ));
         }
 
-        let dim_product = checked_product(&field.dims, "type field dimensions")?;
-        let field_size = if dim_product == 0 {
-            field.base_type_size
+        let field_size = if field.dims.is_empty() {
+            base_type_size
         } else {
-            checked_input_mul(field.base_type_size, dim_product, "type field size")?
+            let dim_product = checked_product(&field.dims, "type field dimensions")?;
+            checked_input_mul(base_type_size, dim_product, "type field size")?
         };
         total_size = checked_input_add(total_size, field_size, "type size")?;
     }
+    visiting.pop();
     Ok(total_size)
+}
+
+fn checked_field_base_size(
+    field: &vm2::TypeField,
+    types: &[vm2::Type],
+    visiting: &mut Vec<usize>,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    match &field.kind {
+        vm2::TypeFieldKind::Ff => Ok(1),
+        vm2::TypeFieldKind::Bus(bus_idx) => {
+            checked_type_size_by_index(*bus_idx, types, visiting)
+        }
+    }
 }
 
 fn checked_product(
@@ -807,6 +832,63 @@ mod tests {
         assert!(result.unwrap().is_err());
     }
 
+    fn graph_with_v2_input_metadata(
+        input_info: &[crate::vm2::InputInfo],
+        types: &[crate::vm2::Type],
+    ) -> Vec<u8> {
+        use crate::graph::{Node, Nodes, NodesInterface, VecNodes};
+        use crate::storage::serialize_witnesscalc_graph;
+
+        let mut nodes = Nodes::new(bn254_prime, "bn128", VecNodes::new());
+        nodes.push_noopt(Node::Input(1));
+
+        let mut bytes = Vec::new();
+        serialize_witnesscalc_graph(&mut bytes, &nodes, &[0], input_info, types).unwrap();
+        bytes
+    }
+
+    fn calc_witness_err(inputs_json: &str, wcd_data: &[u8]) -> String {
+        let result = panic::catch_unwind(|| super::calc_witness(inputs_json, wcd_data));
+        assert!(result.is_ok(), "calc_witness must not panic");
+        result.unwrap().unwrap_err().to_string()
+    }
+
+    #[test]
+    fn test_calc_witness_handles_graph_mod_by_zero() {
+        use crate::graph::{Node, Nodes, NodesInterface, Operation, VecNodes};
+        use crate::storage::serialize_witnesscalc_graph;
+
+        let mut nodes = Nodes::new(bn254_prime, "bn128", VecNodes::new());
+        let zero = nodes.const_node_idx_from_value(U254::from(0));
+        nodes.push_noopt(Node::Input(0));
+        nodes.push_noopt(Node::Op(Operation::Mod, 1, zero));
+
+        let mut bytes = Vec::new();
+        serialize_witnesscalc_graph(&mut bytes, &nodes, &[2], &[], &[]).unwrap();
+
+        let result = panic::catch_unwind(|| super::calc_witness("{}", &bytes));
+        assert!(result.is_ok(), "calc_witness must not panic");
+        assert!(result.unwrap().is_ok());
+    }
+
+    #[test]
+    fn test_calc_witness_rejects_graph_composite_prime() {
+        use crate::graph::{Node, Nodes, NodesInterface, Operation, VecNodes};
+        use crate::storage::serialize_witnesscalc_graph;
+
+        let composite_prime = bn254_prime - U254::from(1);
+        let mut nodes = Nodes::new(composite_prime, "composite", VecNodes::new());
+        let four = nodes.const_node_idx_from_value(U254::from(4));
+        let two = nodes.const_node_idx_from_value(U254::from(2));
+        nodes.push_noopt(Node::Op(Operation::Div, four, two));
+
+        let mut bytes = Vec::new();
+        serialize_witnesscalc_graph(&mut bytes, &nodes, &[2], &[], &[]).unwrap();
+
+        let err = calc_witness_err("{}", &bytes);
+        assert!(err.contains("Unsupported graph prime"));
+    }
+
     #[test]
     fn test_graph_v1_input_metadata_overflow_returns_error() {
         let input_list: HashMap<String, Vec<U254>> = HashMap::new();
@@ -856,6 +938,80 @@ mod tests {
         let err = super::init_inputs_from_v2("{}", &ff, &input_info, &types)
             .unwrap_err();
         assert!(err.to_string().contains("Bus type index is out of range"));
+    }
+
+    #[test]
+    fn test_calc_witness_rejects_nested_invalid_bus_index() {
+        let input_info = vec![crate::vm2::InputInfo {
+            name: "a".to_string(),
+            offset: 0,
+            lengths: vec![],
+            type_id: Some("outer".to_string()),
+        }];
+        let types = vec![
+            crate::vm2::Type {
+                name: "outer".to_string(),
+                fields: vec![crate::vm2::TypeField {
+                    name: "inner".to_string(),
+                    kind: crate::vm2::TypeFieldKind::Bus(1),
+                    offset: 0,
+                    base_type_size: 1,
+                    dims: vec![],
+                }],
+            },
+            crate::vm2::Type {
+                name: "inner".to_string(),
+                fields: vec![crate::vm2::TypeField {
+                    name: "bad".to_string(),
+                    kind: crate::vm2::TypeFieldKind::Bus(99),
+                    offset: 0,
+                    base_type_size: 1,
+                    dims: vec![],
+                }],
+            },
+        ];
+        let bytes = graph_with_v2_input_metadata(&input_info, &types);
+
+        let err = calc_witness_err("{}", &bytes);
+        assert!(err.contains("Bus type index is out of range"));
+    }
+
+    #[test]
+    fn test_calc_witness_rejects_type_base_size_desync() {
+        let input_info = vec![crate::vm2::InputInfo {
+            name: "a".to_string(),
+            offset: 0,
+            lengths: vec![],
+            type_id: Some("bus".to_string()),
+        }];
+        let types = vec![crate::vm2::Type {
+            name: "bus".to_string(),
+            fields: vec![crate::vm2::TypeField {
+                name: "x".to_string(),
+                kind: crate::vm2::TypeFieldKind::Ff,
+                offset: 0,
+                base_type_size: 2,
+                dims: vec![],
+            }],
+        }];
+        let bytes = graph_with_v2_input_metadata(&input_info, &types);
+
+        let err = calc_witness_err("{}", &bytes);
+        assert!(err.contains("base_type_size"));
+    }
+
+    #[test]
+    fn test_calc_witness_rejects_out_of_range_root_array_input() {
+        let input_info = vec![crate::vm2::InputInfo {
+            name: "a".to_string(),
+            offset: 0,
+            lengths: vec![1],
+            type_id: None,
+        }];
+        let bytes = graph_with_v2_input_metadata(&input_info, &[]);
+
+        let err = calc_witness_err(r#"{"[999999]": "3"}"#, &bytes);
+        assert!(err.contains("outside input signal range"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@ use crate::field::{bn254_prime, Field, FieldOperations, FieldOps, U254, U64};
 use crate::storage::proto_deserializer::{deserialize_witnesscalc_graph_from_bytes, InputInfo};
 use crate::storage::{deserialize_witnesscalc_vm2_body, read_witnesscalc_vm2_header, WITNESSCALC_CVM_MAGIC, WITNESSCALC_GRAPH_MAGIC_002, WITNESSCALC_GRAPH_MAGIC_001};
 use crate::vm2::{execute, Circuit, Component};
-use crate::vm2::InputInfoSliceExt;
 use crate::vm2_setup::{build_component_tree, init_signals};
 
 pub type InputSignalsInfo = HashMap<String, (usize, usize)>;
@@ -43,6 +42,10 @@ pub mod proto {
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 // include!("bindings.rs");
+
+// Graph V2 input metadata is untrusted; cap the temporary component used to
+// parse inputs before Component::new performs infallible signal allocation.
+const MAX_GRAPH_V2_INPUT_SIGNALS: usize = 1 << 24;
 
 fn prepare_status(status: *mut gw_status_t, code: GW_ERROR_CODE, error_msg: &str) {
     if !status.is_null() {
@@ -241,12 +244,13 @@ fn init_inputs_from_inputs_mapping<T: FieldOps>(
 
     let mut inputs_len: usize = 1;
     for (offset, len) in inputs_info.values() {
-        let idx = offset + len;
+        let idx = checked_input_add(*offset, *len, "offset plus length")?;
         if idx > inputs_len {
             inputs_len = idx;
         }
     }
-    let mut inputs = vec![T::zero(); inputs_len];
+    let mut inputs = try_reserve_input_vec(inputs_len, "V1 inputs")?;
+    inputs.resize(inputs_len, T::zero());
     inputs[0] = T::one();
     let mut inputs_filled = 1;
     for (key, value) in input_list {
@@ -279,25 +283,164 @@ fn init_inputs_from_v2<T: FieldOps>(
     input_info: &[vm2::InputInfo],
     types: &[vm2::Type],
 ) -> Result<Vec<T>, Box<dyn std::error::Error>> {
-    let inputs_size = input_info.get_total_size(types)?;
-    let min_offset = input_info.min_offset().unwrap_or(0);
-    let signals_num = min_offset + inputs_size;
-    let mut component = Component::new(0, 0, vec![], inputs_size, signals_num);
+    let (inputs_size, min_offset) = checked_v2_input_layout(input_info, types)?;
+    checked_component_input_count(inputs_size)?;
+    let shifted_input_info = shift_input_offsets(input_info, min_offset)?;
+    let mut component = Component::new(0, 0, vec![], inputs_size, inputs_size);
     let inputs_cursor = Cursor::new(inputs_json.as_bytes());
-    init_signals(inputs_cursor, ff, types, input_info, &mut component)?;
-    let mut component_signals = Vec::with_capacity(signals_num);
+    init_signals(inputs_cursor, ff, types, &shifted_input_info, &mut component)?;
+    let mut component_signals = try_reserve_input_vec(inputs_size, "V2 component output")?;
     component.write_all_signals(&mut component_signals);
 
-    let mut inputs = Vec::with_capacity(inputs_size + 1);
+    let inputs_capacity = checked_input_add(inputs_size, 1, "inputs size plus one")?;
+    let mut inputs = try_reserve_input_vec(inputs_capacity, "V2 inputs")?;
     inputs.push(T::one());
     inputs.extend(
         component_signals.iter()
-            .skip(min_offset)
             .take(inputs_size)
             .map(|x| x.expect(
                 "[assertion] init_signals should not allow None input signals")));
 
     Ok(inputs)
+}
+
+fn checked_v2_input_layout(
+    input_info: &[vm2::InputInfo],
+    types: &[vm2::Type],
+) -> Result<(usize, usize), Box<dyn std::error::Error>> {
+    let mut inputs_size = 0usize;
+    let mut ranges = try_reserve_input_vec(input_info.len(), "V2 input ranges")?;
+    for info in input_info {
+        let base_type_size = match &info.type_id {
+            None => 1,
+            Some(type_id) => {
+                let ty = types.iter()
+                    .find(|ty| &ty.name == type_id)
+                    .ok_or_else(|| invalid_input_metadata("Unknown input type"))?;
+                checked_type_size(ty, types)?
+            }
+        };
+        let array_count = checked_product(&info.lengths, "input dimensions")?;
+        let input_size = checked_input_mul(array_count, base_type_size, "input size")?;
+        if input_size == 0 {
+            return Err(invalid_input_metadata("Input metadata size must be nonzero"));
+        }
+        inputs_size = checked_input_add(inputs_size, input_size, "total input size")?;
+        let end = checked_input_add(info.offset, input_size, "input offset plus size")?;
+        ranges.push((info.offset, end));
+    }
+
+    ranges.sort_by_key(|(offset, _)| *offset);
+    let min_offset = ranges.first().map(|(offset, _)| *offset).unwrap_or(0);
+    let mut expected_offset = min_offset;
+    for (offset, end) in ranges {
+        if offset != expected_offset {
+            return Err(invalid_input_metadata(
+                "Input metadata offsets must be contiguous and non-overlapping",
+            ));
+        }
+        expected_offset = end;
+    }
+    let signals_num = checked_input_add(min_offset, inputs_size, "signal count")?;
+    if expected_offset != signals_num {
+        return Err(invalid_input_metadata("Input metadata span is inconsistent"));
+    }
+    Ok((inputs_size, min_offset))
+}
+
+fn shift_input_offsets(
+    input_info: &[vm2::InputInfo],
+    min_offset: usize,
+) -> Result<Vec<vm2::InputInfo>, Box<dyn std::error::Error>> {
+    let mut shifted = try_reserve_input_vec(input_info.len(), "V2 shifted input info")?;
+    for info in input_info {
+        let mut shifted_info = info.clone();
+        shifted_info.offset = info.offset.checked_sub(min_offset).ok_or_else(|| {
+            invalid_input_metadata("Input metadata offset is below minimum offset")
+        })?;
+        shifted.push(shifted_info);
+    }
+    Ok(shifted)
+}
+
+fn checked_component_input_count(
+    signals_num: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if signals_num > MAX_GRAPH_V2_INPUT_SIGNALS {
+        return Err(invalid_input_metadata(
+            "Input metadata V2 input count is too large",
+        ));
+    }
+    Ok(())
+}
+
+fn checked_type_size(
+    ty: &vm2::Type,
+    types: &[vm2::Type],
+) -> Result<usize, Box<dyn std::error::Error>> {
+    let mut total_size = 0usize;
+    for field in &ty.fields {
+        if let vm2::TypeFieldKind::Bus(bus_idx) = &field.kind {
+            if *bus_idx >= types.len() {
+                return Err(invalid_input_metadata("Bus type index is out of range"));
+            }
+        }
+
+        let dim_product = checked_product(&field.dims, "type field dimensions")?;
+        let field_size = if dim_product == 0 {
+            field.base_type_size
+        } else {
+            checked_input_mul(field.base_type_size, dim_product, "type field size")?
+        };
+        total_size = checked_input_add(total_size, field_size, "type size")?;
+    }
+    Ok(total_size)
+}
+
+fn checked_product(
+    values: &[usize],
+    context: &str,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    values.iter().try_fold(1usize, |acc, value| {
+        checked_input_mul(acc, *value, context)
+    })
+}
+
+fn checked_input_add(
+    lhs: usize,
+    rhs: usize,
+    context: &str,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    lhs.checked_add(rhs).ok_or_else(|| {
+        invalid_input_metadata(format!("Input metadata {} overflows usize", context))
+    })
+}
+
+fn checked_input_mul(
+    lhs: usize,
+    rhs: usize,
+    context: &str,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    lhs.checked_mul(rhs).ok_or_else(|| {
+        invalid_input_metadata(format!("Input metadata {} overflows usize", context))
+    })
+}
+
+fn try_reserve_input_vec<T>(
+    len: usize,
+    context: &str,
+) -> Result<Vec<T>, Box<dyn std::error::Error>> {
+    let mut vec = Vec::new();
+    vec.try_reserve(len).map_err(|_| {
+        invalid_input_metadata(format!(
+            "Input metadata {} exceeds available memory",
+            context))
+    })?;
+    Ok(vec)
+}
+
+fn invalid_input_metadata(message: impl Into<String>) -> Box<dyn std::error::Error> {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, message.into()).into()
 }
 
 #[derive(Debug)]
@@ -662,5 +805,124 @@ mod tests {
         let result = panic::catch_unwind(|| super::calc_witness("{}", &bytes));
         assert!(result.is_ok(), "calc_witness must not panic");
         assert!(result.unwrap().is_err());
+    }
+
+    #[test]
+    fn test_graph_v1_input_metadata_overflow_returns_error() {
+        let input_list: HashMap<String, Vec<U254>> = HashMap::new();
+        let mut inputs_info = super::InputSignalsInfo::new();
+        inputs_info.insert("a".to_string(), (usize::MAX, 1));
+
+        let err = super::init_inputs_from_inputs_mapping(&input_list, &inputs_info)
+            .unwrap_err();
+        assert!(err.to_string().contains("overflows usize"));
+    }
+
+    #[test]
+    fn test_graph_v2_input_metadata_overflow_returns_error() {
+        let ff = Field::new(bn254_prime);
+        let input_info = vec![crate::vm2::InputInfo {
+            name: "a".to_string(),
+            offset: 0,
+            lengths: vec![usize::MAX, 2],
+            type_id: None,
+        }];
+
+        let err = super::init_inputs_from_v2("{}", &ff, &input_info, &[])
+            .unwrap_err();
+        assert!(err.to_string().contains("overflows usize"));
+    }
+
+    #[test]
+    fn test_graph_v2_input_metadata_rejects_invalid_bus_index() {
+        let ff = Field::new(bn254_prime);
+        let input_info = vec![crate::vm2::InputInfo {
+            name: "a".to_string(),
+            offset: 0,
+            lengths: vec![],
+            type_id: Some("bus".to_string()),
+        }];
+        let types = vec![crate::vm2::Type {
+            name: "bus".to_string(),
+            fields: vec![crate::vm2::TypeField {
+                name: "x".to_string(),
+                kind: crate::vm2::TypeFieldKind::Bus(7),
+                offset: 0,
+                base_type_size: 1,
+                dims: vec![],
+            }],
+        }];
+
+        let err = super::init_inputs_from_v2("{}", &ff, &input_info, &types)
+            .unwrap_err();
+        assert!(err.to_string().contains("Bus type index is out of range"));
+    }
+
+    #[test]
+    fn test_graph_v2_input_metadata_rejects_sparse_offsets() {
+        let ff = Field::new(bn254_prime);
+        let input_info = vec![
+            crate::vm2::InputInfo {
+                name: "a".to_string(),
+                offset: 0,
+                lengths: vec![1],
+                type_id: None,
+            },
+            crate::vm2::InputInfo {
+                name: "b".to_string(),
+                offset: 4,
+                lengths: vec![1],
+                type_id: None,
+            },
+        ];
+
+        let err = super::init_inputs_from_v2("{}", &ff, &input_info, &[])
+            .unwrap_err();
+        assert!(err.to_string().contains("contiguous"));
+    }
+
+    #[test]
+    fn test_graph_v2_input_metadata_rejects_zero_sized_input() {
+        let ff = Field::new(bn254_prime);
+        let input_info = vec![crate::vm2::InputInfo {
+            name: "a".to_string(),
+            offset: 0,
+            lengths: vec![0],
+            type_id: None,
+        }];
+
+        let err = super::init_inputs_from_v2("{}", &ff, &input_info, &[])
+            .unwrap_err();
+        assert!(err.to_string().contains("must be nonzero"));
+    }
+
+    #[test]
+    fn test_graph_v2_input_metadata_accepts_nonzero_contiguous_offsets() {
+        let ff = Field::new(bn254_prime);
+        let input_info = vec![crate::vm2::InputInfo {
+            name: "a".to_string(),
+            offset: 7,
+            lengths: vec![1],
+            type_id: None,
+        }];
+
+        let inputs = super::init_inputs_from_v2("{\"a\":[\"9\"]}", &ff, &input_info, &[])
+            .unwrap();
+        assert_eq!(inputs, vec![U254::from(1), U254::from(9)]);
+    }
+
+    #[test]
+    fn test_graph_v2_input_metadata_rejects_oversized_component() {
+        let ff = Field::new(bn254_prime);
+        let input_info = vec![crate::vm2::InputInfo {
+            name: "a".to_string(),
+            offset: 0,
+            lengths: vec![super::MAX_GRAPH_V2_INPUT_SIGNALS + 1],
+            type_id: None,
+        }];
+
+        let err = super::init_inputs_from_v2("{}", &ff, &input_info, &[])
+            .unwrap_err();
+        assert!(err.to_string().contains("input count is too large"));
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -34,6 +34,37 @@ fn write_signal<W: Write>(w: &mut W, signal: &vm2::Signal) -> std::io::Result<()
     Ok(())
 }
 
+/// Allocate a `Vec` with capacity for `count` elements decoded from an
+/// artifact. The count is attacker-controlled, so reserve fallibly and return
+/// an error instead of letting an implausibly large value abort the process
+/// with an out-of-memory allocation.
+fn reserve_from_count<T>(count: usize) -> std::io::Result<Vec<T>> {
+    let mut vec = Vec::new();
+    vec.try_reserve(count).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Decoded element count exceeds available memory",
+        )
+    })?;
+    Ok(vec)
+}
+
+/// Read exactly `len` bytes from an artifact into a fresh `Vec`. `len` is
+/// attacker-controlled, so grow the buffer to the bytes actually available
+/// (bounded by `take`) instead of allocating `len` up front, which for a
+/// corrupt length would abort the process with an out-of-memory error.
+fn read_exact_vec<R: Read>(r: &mut R, len: usize) -> std::io::Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    r.take(len as u64).read_to_end(&mut buf)?;
+    if buf.len() != len {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "Artifact ended before the declared length",
+        ));
+    }
+    Ok(buf)
+}
+
 fn read_signal<R: Read>(r: &mut R) -> std::io::Result<vm2::Signal> {
     let signal_type = r.read_u8()?;
     match signal_type {
@@ -373,32 +404,42 @@ pub fn serialize_witnesscalc_vm(
 }
 
 fn read_message_length<R: Read>(rw: &mut WriteBackReader<R>) -> std::io::Result<usize> {
-    let mut buf = [0u8; MAX_VARINT_LENGTH];
-    let bytes_read = rw.read(&mut buf)?;
-    if bytes_read == 0 {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::UnexpectedEof, "Unexpected EOF"));
+    let mut value = 0u64;
+    for i in 0..MAX_VARINT_LENGTH {
+        let mut byte = [0u8; 1];
+        if rw.read(&mut byte)? == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "Unexpected EOF while reading length delimiter",
+            ));
+        }
+
+        if i == MAX_VARINT_LENGTH - 1 && byte[0] > 1 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Length delimiter does not fit u64",
+            ));
+        }
+        value |= ((byte[0] & 0x7f) as u64) << (7 * i);
+        if byte[0] < 0x80 {
+            return usize::try_from(value).map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Length delimiter does not fit usize",
+                )
+            });
+        }
     }
 
-    let len_delimiter = prost::decode_length_delimiter(buf.as_ref())?;
-
-    let lnln = prost::length_delimiter_len(len_delimiter);
-
-    if lnln < bytes_read {
-        rw.write_all(&buf[lnln..bytes_read])?;
-    }
-
-    Ok(len_delimiter)
+    Err(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "Length delimiter varint is too long",
+    ))
 }
 
 fn read_message<R: Read, M: Message + Default>(rw: &mut WriteBackReader<R>) -> std::io::Result<M> {
     let ln = read_message_length(rw)?;
-    let mut buf = vec![0u8; ln];
-    let bytes_read = rw.read(&mut buf)?;
-    if bytes_read != ln {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::UnexpectedEof, "Unexpected EOF"));
-    }
+    let buf = read_exact_vec(rw, ln)?;
 
     let msg = prost::Message::decode(&buf[..])?;
 
@@ -643,32 +684,37 @@ pub fn serialize_input_signal_info(
 
 pub fn deserialize_input_infos<R: Read>(r: &mut R) -> std::io::Result<Vec<vm2::InputInfo>> {
     let num_input_infos = r.read_u32::<LittleEndian>()? as usize;
-    let mut input_infos = Vec::with_capacity(num_input_infos);
+    let mut input_infos = reserve_from_count(num_input_infos)?;
 
     for _ in 0..num_input_infos {
         let name_len = r.read_u32::<LittleEndian>()? as usize;
-        let mut name_bytes = vec![0u8; name_len];
-        r.read_exact(&mut name_bytes)?;
+        let name_bytes = read_exact_vec(r, name_len)?;
         let name = String::from_utf8(name_bytes)
             .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid UTF-8 in input name"))?;
 
         let offset = r.read_u32::<LittleEndian>()? as usize;
 
         let num_lengths = r.read_u32::<LittleEndian>()? as usize;
-        let mut lengths = Vec::with_capacity(num_lengths);
+        let mut lengths = reserve_from_count(num_lengths)?;
         for _ in 0..num_lengths {
             lengths.push(r.read_u32::<LittleEndian>()? as usize);
         }
 
         let has_type_id = r.read_u8()?;
-        let type_id = if has_type_id == 1 {
-            let type_id_len = r.read_u32::<LittleEndian>()? as usize;
-            let mut type_id_bytes = vec![0u8; type_id_len];
-            r.read_exact(&mut type_id_bytes)?;
-            Some(String::from_utf8(type_id_bytes)
-                .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid UTF-8 in type_id"))?)
-        } else {
-            None
+        let type_id = match has_type_id {
+            0 => None,
+            1 => {
+                let type_id_len = r.read_u32::<LittleEndian>()? as usize;
+                let type_id_bytes = read_exact_vec(r, type_id_len)?;
+                Some(String::from_utf8(type_id_bytes)
+                    .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid UTF-8 in type_id"))?)
+            }
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid input type_id discriminator",
+                ));
+            }
         };
 
         input_infos.push(vm2::InputInfo {
@@ -684,22 +730,20 @@ pub fn deserialize_input_infos<R: Read>(r: &mut R) -> std::io::Result<Vec<vm2::I
 
 pub fn deserialize_types<R: Read>(r: &mut R) -> std::io::Result<Vec<vm2::Type>> {
     let num_types = r.read_u32::<LittleEndian>()? as usize;
-    let mut types = Vec::with_capacity(num_types);
+    let mut types = reserve_from_count(num_types)?;
 
     for _ in 0..num_types {
         let name_len = r.read_u32::<LittleEndian>()? as usize;
-        let mut name_bytes = vec![0u8; name_len];
-        r.read_exact(&mut name_bytes)?;
+        let name_bytes = read_exact_vec(r, name_len)?;
         let name = String::from_utf8(name_bytes)
             .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid UTF-8 in type name"))?;
 
         let num_fields = r.read_u32::<LittleEndian>()? as usize;
-        let mut fields = Vec::with_capacity(num_fields);
+        let mut fields = reserve_from_count(num_fields)?;
 
         for _ in 0..num_fields {
             let field_name_len = r.read_u32::<LittleEndian>()? as usize;
-            let mut field_name_bytes = vec![0u8; field_name_len];
-            r.read_exact(&mut field_name_bytes)?;
+            let field_name_bytes = read_exact_vec(r, field_name_len)?;
             let field_name = String::from_utf8(field_name_bytes)
                 .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid UTF-8 in field name"))?;
 
@@ -717,7 +761,7 @@ pub fn deserialize_types<R: Read>(r: &mut R) -> std::io::Result<Vec<vm2::Type>> 
             let base_type_size = r.read_u32::<LittleEndian>()? as usize;
 
             let num_dims = r.read_u32::<LittleEndian>()? as usize;
-            let mut dims = Vec::with_capacity(num_dims);
+            let mut dims = reserve_from_count(num_dims)?;
             for _ in 0..num_dims {
                 dims.push(r.read_u32::<LittleEndian>()? as usize);
             }
@@ -744,6 +788,13 @@ pub fn deserialize_input_signal_info(data: &[u8]) -> std::io::Result<(Vec<vm2::I
     let mut cursor = std::io::Cursor::new(data);
     let input_infos = deserialize_input_infos(&mut cursor)?;
     let types = deserialize_types(&mut cursor)?;
+    let mut trailing = [0u8; 1];
+    if cursor.read(&mut trailing)? != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Trailing bytes in input signal info",
+        ));
+    }
     Ok((input_infos, types))
 }
 
@@ -998,7 +1049,9 @@ mod tests {
     use crate::vm::ComponentTmpl;
     use crate::field::{bn254_prime, FieldOperations, U254, U64};
     use crate::InputSignalsInfo;
-    use crate::storage::proto_deserializer::{deserialize_witnesscalc_graph_from_bytes, InputInfo};
+    use crate::storage::proto_deserializer::{
+        decode_node, decode_varint_u32, deserialize_witnesscalc_graph_from_bytes, InputInfo,
+    };
     use super::*;
 
     #[test]
@@ -1166,6 +1219,210 @@ mod tests {
         };
 
         assert_eq!(metadata, metadata_want);
+    }
+
+    fn graph_decode_error(bytes: &[u8]) -> std::io::Error {
+        match deserialize_witnesscalc_graph_from_bytes(bytes) {
+            Ok(_) => panic!("expected graph decode error"),
+            Err(err) => err,
+        }
+    }
+
+    fn graph_artifact(
+        nodes_num: u64,
+        node_bytes: &[u8],
+        metadata_bytes: &[u8],
+        metadata_ptr: u64,
+    ) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(WITNESSCALC_GRAPH_MAGIC_002);
+        bytes.write_u64::<LittleEndian>(nodes_num).unwrap();
+        bytes.extend_from_slice(node_bytes);
+        bytes.extend_from_slice(metadata_bytes);
+        bytes.write_u64::<LittleEndian>(metadata_ptr).unwrap();
+        bytes
+    }
+
+    fn malformed_graph_artifact(nodes_num: u64, node_bytes: &[u8], metadata_ptr: u64) -> Vec<u8> {
+        graph_artifact(nodes_num, node_bytes, &[0], metadata_ptr)
+    }
+
+    #[test]
+    fn test_graph_magic_only_returns_unexpected_eof() {
+        let err = graph_decode_error(WITNESSCALC_GRAPH_MAGIC_002);
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn test_graph_missing_node_count_returns_unexpected_eof() {
+        let mut bytes = WITNESSCALC_GRAPH_MAGIC_002.to_vec();
+        bytes.extend_from_slice(&[0; 7]);
+
+        let err = graph_decode_error(&bytes);
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn test_graph_missing_metadata_pointer_returns_unexpected_eof() {
+        let mut bytes = WITNESSCALC_GRAPH_MAGIC_002.to_vec();
+        bytes.write_u64::<LittleEndian>(0).unwrap();
+
+        let err = graph_decode_error(&bytes);
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn test_graph_metadata_pointer_past_end_returns_invalid_data() {
+        let bytes = malformed_graph_artifact(0, &[], u64::MAX);
+
+        let err = graph_decode_error(&bytes);
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_graph_node_length_past_artifact_returns_unexpected_eof() {
+        let node_bytes = [0xff, 0x01];
+        let metadata_ptr = (WITNESSCALC_GRAPH_MAGIC_002.len() + 8 + node_bytes.len()) as u64;
+        let bytes = malformed_graph_artifact(1, &node_bytes, metadata_ptr);
+
+        let err = graph_decode_error(&bytes);
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn test_graph_node_bytes_must_end_at_metadata_pointer() {
+        let node_bytes = [0];
+        let metadata_ptr = (WITNESSCALC_GRAPH_MAGIC_002.len() + 8 + node_bytes.len()) as u64;
+        let bytes = malformed_graph_artifact(0, &node_bytes, metadata_ptr);
+
+        let err = graph_decode_error(&bytes);
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_graph_metadata_must_consume_full_region() {
+        let metadata_ptr = (WITNESSCALC_GRAPH_MAGIC_002.len() + 8) as u64;
+        let bytes = graph_artifact(0, &[], &[0, 0], metadata_ptr);
+
+        let err = graph_decode_error(&bytes);
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_graph_truncated_metadata_length_returns_unexpected_eof() {
+        let metadata_ptr = (WITNESSCALC_GRAPH_MAGIC_002.len() + 8) as u64;
+        let bytes = graph_artifact(0, &[], &[0x80], metadata_ptr);
+
+        let err = graph_decode_error(&bytes);
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn test_graph_overlong_metadata_length_returns_invalid_data() {
+        let metadata_ptr = (WITNESSCALC_GRAPH_MAGIC_002.len() + 8) as u64;
+        let bytes = graph_artifact(0, &[], &[0xff; MAX_VARINT_LENGTH], metadata_ptr);
+
+        let err = graph_decode_error(&bytes);
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_duplicate_constant_nodes_return_invalid_data() {
+        let constant = crate::proto::node::Node::Constant(crate::proto::ConstantNode {
+            value: Some(crate::proto::BigUInt { value_le: vec![7] }),
+        });
+        let mut node_bytes = Vec::new();
+        crate::proto::Node {
+            node: Some(constant.clone()),
+        }
+        .encode_length_delimited(&mut node_bytes)
+        .unwrap();
+        crate::proto::Node {
+            node: Some(constant),
+        }
+        .encode_length_delimited(&mut node_bytes)
+        .unwrap();
+
+        let metadata_ptr = (WITNESSCALC_GRAPH_MAGIC_002.len() + 8 + node_bytes.len()) as u64;
+        let bytes = malformed_graph_artifact(2, &node_bytes, metadata_ptr);
+
+        let err = graph_decode_error(&bytes);
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_unknown_node_field_number_returns_invalid_data() {
+        let mut nodes = Nodes::new(bn254_prime, "bn128", VecNodes::new());
+        let err = decode_node(&[0x32, 0x00], &mut nodes).unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("field number 6"));
+    }
+
+    #[test]
+    fn test_invalid_protobuf_wire_type_returns_invalid_data() {
+        let mut nodes = Nodes::new(bn254_prime, "bn128", VecNodes::new());
+        let err = decode_node(&[0x0e], &mut nodes).unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("Invalid protobuf wire type 6"));
+    }
+
+    #[test]
+    fn test_varint_errors_do_not_panic() {
+        let err = decode_varint_u32(&[0x80]).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+
+        let err = decode_varint_u32(&[0x80, 0x80, 0x80, 0x80, 0x80]).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_decode_rejects_absurd_element_count() {
+        // A count of u32::MAX with no payload must return an error rather than
+        // attempt a multi-gigabyte up-front allocation and abort the process.
+        let mut bytes = Vec::new();
+        bytes.write_u32::<LittleEndian>(u32::MAX).unwrap();
+        let err = deserialize_input_infos(&mut std::io::Cursor::new(bytes)).unwrap_err();
+        assert!(matches!(
+            err.kind(),
+            std::io::ErrorKind::InvalidData | std::io::ErrorKind::UnexpectedEof
+        ));
+    }
+
+    #[test]
+    fn test_decode_rejects_absurd_byte_length() {
+        // One input info whose name claims u32::MAX bytes with none following
+        // must return an error rather than allocate the buffer up front.
+        let mut bytes = Vec::new();
+        bytes.write_u32::<LittleEndian>(1).unwrap();
+        bytes.write_u32::<LittleEndian>(u32::MAX).unwrap();
+        let err = deserialize_input_infos(&mut std::io::Cursor::new(bytes)).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn test_decode_rejects_invalid_type_id_discriminator() {
+        let mut bytes = Vec::new();
+        bytes.write_u32::<LittleEndian>(1).unwrap();
+        bytes.write_u32::<LittleEndian>(0).unwrap();
+        bytes.write_u32::<LittleEndian>(0).unwrap();
+        bytes.write_u32::<LittleEndian>(0).unwrap();
+        bytes.write_u8(2).unwrap();
+
+        let err = deserialize_input_infos(&mut std::io::Cursor::new(bytes)).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_decode_rejects_trailing_input_signal_info() {
+        let mut bytes = Vec::new();
+        bytes.write_u32::<LittleEndian>(0).unwrap();
+        bytes.write_u32::<LittleEndian>(0).unwrap();
+        bytes.push(0);
+
+        let err = deserialize_input_signal_info(&bytes).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 
     #[test]

--- a/src/storage/proto_deserializer.rs
+++ b/src/storage/proto_deserializer.rs
@@ -1,5 +1,5 @@
 use std::io::{Cursor, Error, ErrorKind, Read};
-use crate::field::{FieldOperations, FieldOps, U254, U64};
+use crate::field::{bn254_prime, FieldOperations, FieldOps, U254, U64};
 use crate::graph::{Node, Nodes, NodesInterface, NodesStorage, Operation, TresOperation, UnoOperation, VecNodes};
 use crate::InputSignalsInfo;
 use crate::storage::{deserialize_input_signal_info, read_message, WriteBackReader, WITNESSCALC_GRAPH_MAGIC_002, WITNESSCALC_GRAPH_MAGIC_001};
@@ -90,33 +90,26 @@ pub fn deserialize_witnesscalc_graph_from_bytes(
         )
     };
 
-    let outer_nodes: Box<dyn NodesInterface> = match prime.bit_len() {
-        64 => {
-            let prime = U64::from_le_bytes(
-                &<U254 as FieldOps>::to_le_bytes(&prime))
-                .map_err(|err| {
-                    Error::new(
-                        ErrorKind::InvalidData,
-                        format!("Invalid 64-bit metadata prime: {}", err),
-                    )
-                })?;
+    let outer_nodes: Box<dyn NodesInterface> = match graph_prime_kind(prime) {
+        Some(GraphPrimeKind::Goldilocks) => {
+            let prime = U64::new(GOLDILOCKS_PRIME);
             let node_storage = VecNodes::new();
             let mut nodes = Nodes::new(
                 prime, curve_name, node_storage);
             decode_graph_nodes(bytes, idx, nodes_num, metadata_offset, &mut nodes)?;
             Box::new(nodes)
         }
-        254 => {
+        Some(GraphPrimeKind::Bn254) => {
             let node_storage = VecNodes::new();
             let mut nodes = Nodes::new(
                 prime, curve_name, node_storage);
             decode_graph_nodes(bytes, idx, nodes_num, metadata_offset, &mut nodes)?;
             Box::new(nodes)
         }
-        _ => {
+        None => {
             return Err(Error::new(
                 ErrorKind::InvalidData,
-                format!("unknown prime {}", md.prime_str)));
+                format!("Unsupported graph prime {}", prime)));
         }
     };
 
@@ -148,6 +141,23 @@ pub fn deserialize_witnesscalc_graph_from_bytes(
     };
 
     Ok((outer_nodes, witness_signals, inputs_info))
+}
+
+const GOLDILOCKS_PRIME: u64 = 18446744069414584321;
+
+enum GraphPrimeKind {
+    Bn254,
+    Goldilocks,
+}
+
+fn graph_prime_kind(prime: U254) -> Option<GraphPrimeKind> {
+    if prime == bn254_prime {
+        Some(GraphPrimeKind::Bn254)
+    } else if prime == U254::from(GOLDILOCKS_PRIME) {
+        Some(GraphPrimeKind::Goldilocks)
+    } else {
+        None
+    }
 }
 
 fn read_u64_le(bytes: &[u8], offset: usize, context: &str) -> Result<u64, Error> {

--- a/src/storage/proto_deserializer.rs
+++ b/src/storage/proto_deserializer.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Error, ErrorKind};
+use std::io::{Cursor, Error, ErrorKind, Read};
 use crate::field::{FieldOperations, FieldOps, U254, U64};
 use crate::graph::{Node, Nodes, NodesInterface, NodesStorage, Operation, TresOperation, UnoOperation, VecNodes};
 use crate::InputSignalsInfo;
@@ -29,28 +29,64 @@ pub fn deserialize_witnesscalc_graph_from_bytes(
         return Err(Error::other("Invalid magic"));
     };
 
-    let nodes_num = u64::from_le_bytes(bytes[idx..idx+8].try_into().unwrap());
+    let nodes_num = read_u64_le(bytes, idx, "Graph artifact missing node count")?;
     idx += 8;
 
-    let vm_ptr = u64::from_le_bytes(bytes[bytes.len() - 8..bytes.len()]
-        .try_into().unwrap());
-    let r = Cursor::new(&bytes[vm_ptr as usize..]);
+    // Layout: [magic][u64 node count][node messages][metadata][u64 metadata offset].
+    // The trailing u64 records where the metadata message begins.
+    const MISSING_METADATA_PTR: &str = "Graph artifact missing trailing metadata pointer";
+    if bytes.len() - idx < 8 {
+        return Err(Error::new(ErrorKind::UnexpectedEof, MISSING_METADATA_PTR));
+    }
+
+    let metadata_ptr_slot = bytes.len() - 8;
+    let metadata_offset = read_u64_le(bytes, metadata_ptr_slot, MISSING_METADATA_PTR)?;
+    let metadata_offset: usize = metadata_offset.try_into().map_err(|_| {
+        Error::new(
+            ErrorKind::InvalidData,
+            format!("Metadata offset {} cannot fit usize", metadata_offset),
+        )
+    })?;
+    if metadata_offset < idx || metadata_offset > metadata_ptr_slot {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            format!("Metadata offset {} is outside graph payload", metadata_offset),
+        ));
+    }
+
+    let metadata_bytes = checked_range(
+        bytes,
+        metadata_offset,
+        metadata_ptr_slot - metadata_offset,
+        "Graph metadata bytes are truncated",
+    )?;
+    let r = Cursor::new(metadata_bytes);
     let mut br = WriteBackReader::new(r);
     let md: crate::proto::GraphMetadata = read_message(&mut br)?;
+    let mut trailing = [0u8; 1];
+    if br.read(&mut trailing)? != 0 {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "Graph metadata has trailing bytes",
+        ));
+    }
 
-    let (prime, curve_name) = if md.prime.is_none() {
+    let (prime, curve_name) = if let Some(prime) = &md.prime {
+        (
+            <U254 as FieldOps>::from_le_bytes(prime.value_le.as_slice()).map_err(|err| {
+                Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Invalid metadata prime: {}", err),
+                )
+            })?,
+            md.prime_str.as_str(),
+        )
+    } else {
         (
             U254::from_str(
                 "21888242871839275222246405745257275088548364400416034343698204186575808495617")
                 .unwrap(),
             "bn128"
-        )
-    } else {
-        (
-            <U254 as FieldOps>::from_le_bytes(
-                md.prime.unwrap().value_le.as_slice())
-                .unwrap(),
-            md.prime_str.as_str()
         )
     };
 
@@ -58,28 +94,23 @@ pub fn deserialize_witnesscalc_graph_from_bytes(
         64 => {
             let prime = U64::from_le_bytes(
                 &<U254 as FieldOps>::to_le_bytes(&prime))
-                .unwrap();
+                .map_err(|err| {
+                    Error::new(
+                        ErrorKind::InvalidData,
+                        format!("Invalid 64-bit metadata prime: {}", err),
+                    )
+                })?;
             let node_storage = VecNodes::new();
             let mut nodes = Nodes::new(
                 prime, curve_name, node_storage);
-            for _ in 0..nodes_num {
-                let (msg_len, int_len) = decode_varint_u32(&bytes[idx..])?;
-                idx += int_len;
-                decode_node(&bytes[idx..idx+msg_len as usize], &mut nodes)?;
-                idx += msg_len as usize;
-            }
+            decode_graph_nodes(bytes, idx, nodes_num, metadata_offset, &mut nodes)?;
             Box::new(nodes)
         }
         254 => {
             let node_storage = VecNodes::new();
             let mut nodes = Nodes::new(
                 prime, curve_name, node_storage);
-            for _ in 0..nodes_num {
-                let (msg_len, int_len) = decode_varint_u32(&bytes[idx..])?;
-                idx += int_len;
-                decode_node(&bytes[idx..idx+msg_len as usize], &mut nodes)?;
-                idx += msg_len as usize;
-            }
+            decode_graph_nodes(bytes, idx, nodes_num, metadata_offset, &mut nodes)?;
             Box::new(nodes)
         }
         _ => {
@@ -91,15 +122,24 @@ pub fn deserialize_witnesscalc_graph_from_bytes(
 
     let witness_signals = md.witness_signals
         .iter()
-        .map(|x| *x as usize)
-        .collect::<Vec<usize>>();
+        .map(|x| usize::try_from(*x).map_err(|_| {
+            Error::new(ErrorKind::InvalidData, "Witness signal index does not fit usize")
+        }))
+        .collect::<Result<Vec<usize>, Error>>()?;
 
     let inputs_info = if bytes.starts_with(WITNESSCALC_GRAPH_MAGIC_001) {
-        InputInfo::V1(md.inputs.iter()
+        let inputs = md.inputs.iter()
             .map(|(k, v)| {
-                (k.clone(), (v.offset as usize, v.len as usize))
+                let offset = usize::try_from(v.offset).map_err(|_| {
+                    Error::new(ErrorKind::InvalidData, "Input offset does not fit usize")
+                })?;
+                let len = usize::try_from(v.len).map_err(|_| {
+                    Error::new(ErrorKind::InvalidData, "Input length does not fit usize")
+                })?;
+                Ok((k.clone(), (offset, len)))
             })
-            .collect::<InputSignalsInfo>())
+            .collect::<Result<InputSignalsInfo, Error>>()?;
+        InputInfo::V1(inputs)
     } else if bytes.starts_with(WITNESSCALC_GRAPH_MAGIC_002) {
         let (input_info, types) = deserialize_input_signal_info(&md.input_signal_info)?;
         InputInfo::V2 { input_info, types }
@@ -108,6 +148,92 @@ pub fn deserialize_witnesscalc_graph_from_bytes(
     };
 
     Ok((outer_nodes, witness_signals, inputs_info))
+}
+
+fn read_u64_le(bytes: &[u8], offset: usize, context: &str) -> Result<u64, Error> {
+    let bytes = checked_range(bytes, offset, 8, context)?;
+    let mut buf = [0u8; 8];
+    buf.copy_from_slice(bytes);
+    Ok(u64::from_le_bytes(buf))
+}
+
+fn checked_range<'a>(
+    bytes: &'a [u8],
+    offset: usize,
+    len: usize,
+    context: &str,
+) -> Result<&'a [u8], Error> {
+    let end = offset.checked_add(len).ok_or_else(|| {
+        Error::new(ErrorKind::InvalidData, "Byte range length overflows usize")
+    })?;
+    bytes.get(offset..end).ok_or_else(|| Error::new(ErrorKind::UnexpectedEof, context))
+}
+
+fn decode_graph_nodes<T: FieldOps + 'static, NS: NodesStorage + 'static>(
+    bytes: &[u8],
+    mut idx: usize,
+    nodes_num: u64,
+    metadata_offset: usize,
+    nodes: &mut Nodes<T, NS>,
+) -> Result<(), Error> {
+    for _ in 0..nodes_num {
+        if idx > metadata_offset {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "Node cursor moved past metadata offset",
+            ));
+        }
+
+        let (msg_len, int_len) = decode_varint_u32(&bytes[idx..metadata_offset])?;
+        idx += int_len;
+        let msg_len = msg_len as usize;
+        let msg_end = idx.checked_add(msg_len).ok_or_else(|| {
+            Error::new(ErrorKind::InvalidData, "Node length overflows usize")
+        })?;
+        // Nodes sit before the metadata, so msg_end must stay within it. A node
+        // that runs past the whole artifact is truncation (UnexpectedEof); one
+        // that fits the buffer but spills into the metadata is malformed
+        // (InvalidData).
+        if msg_end > bytes.len() {
+            return Err(Error::new(
+                ErrorKind::UnexpectedEof,
+                "Node length extends past graph artifact",
+            ));
+        }
+        if msg_end > metadata_offset {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "Node length extends past metadata offset",
+            ));
+        }
+
+        let node_bytes = checked_range(
+            bytes,
+            idx,
+            msg_len,
+            "Node bytes are truncated",
+        )?;
+        let nodes_before = nodes.len();
+        decode_node(node_bytes, nodes)?;
+        if nodes.len() != nodes_before + 1 {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "Decoded node record did not produce exactly one graph node",
+            ));
+        }
+        idx = msg_end;
+    }
+
+    if idx != metadata_offset {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            format!(
+                "Decoded node bytes ended at {} but metadata starts at {}",
+                idx, metadata_offset),
+        ));
+    }
+
+    Ok(())
 }
 
 #[repr(u8)]
@@ -175,9 +301,10 @@ pub fn decode_node<T: FieldOps + 'static, NS: NodesStorage + 'static>(
         3 => decode_uno_op_node(bytes, nodes),
         4 => decode_duo_op_node(bytes, nodes),
         5 => decode_tres_op_node(bytes, nodes),
-        _ => {
-            panic!("found unknown node")
-        }
+        _ => Err(Error::new(
+            ErrorKind::InvalidData,
+            format!("Found unknown node field number {}", field_number),
+        )),
     }
 }
 
@@ -490,7 +617,13 @@ fn decode_constant_node<T: FieldOps + 'static, NS: NodesStorage + 'static>(
 fn read_tag(bytes: &[u8]) -> Result<(u32, WireType, usize), Error> {
     let (tag, consumed) = decode_varint_u32(bytes)?;
     let field_number = tag >> 3;
-    let wire_type = TryFrom::<u8>::try_from((tag & 0x7) as u8).unwrap();
+    let wire_type = (tag & 0x7) as u8;
+    let wire_type = WireType::try_from(wire_type).map_err(|_| {
+        Error::new(
+            ErrorKind::InvalidData,
+            format!("Invalid protobuf wire type {}", wire_type),
+        )
+    })?;
     Ok((field_number, wire_type, consumed))
 }
 

--- a/src/vm2_setup.rs
+++ b/src/vm2_setup.rs
@@ -30,7 +30,11 @@ where
         let signal_idx = path_to_signal_idx(path, input_infos, types)
             .ok_or_else(|| format!("signal {} is not found in input infos", path))?;
 
-        let local_idx = signal_idx - first_offset;
+        let local_idx = signal_idx.checked_sub(first_offset)
+            .ok_or_else(|| format!("signal {} is before input signal range", path))?;
+        if local_idx >= signals_set.len() {
+            return Err(format!("signal {} is outside input signal range", path).into());
+        }
         if signals_set[local_idx] {
             return Err(format!("duplicate signal at path {}", path).into());
         }
@@ -51,7 +55,7 @@ fn path_to_signal_idx(path: &str, input_infos: &[InputInfo], types: &[Type]) -> 
     // Handle root array: "[5]" -> first_offset + 5
     if path.starts_with('[') {
         if let Some(idx) = parse_root_array_index(path) {
-            return Some(input_infos.first()?.offset + idx);
+            return input_infos.first()?.offset.checked_add(idx);
         }
     }
 
@@ -69,7 +73,7 @@ fn path_to_signal_idx(path: &str, input_infos: &[InputInfo], types: &[Type]) -> 
         }
 
         if let Some(offset) = calculate_offset_from_suffix(suffix, info, types) {
-            return Some(info.offset + offset);
+            return info.offset.checked_add(offset);
         }
     }
 


### PR DESCRIPTION
## Summary

`calc_witness` parses a caller-supplied witness-calculation artifact (`.wcd`) and runs it. On the graph artifact path, malformed or adversarially crafted bytes could panic or abort the process: out-of-bounds slicing while decoding, allocations sized from untrusted counts and lengths, out-of-range node and input-signal indices dereferenced during evaluation, a modulo-by-zero, and an unvalidated field modulus that left a modular inverse undefined. This change makes the graph path return an error for these inputs while leaving valid artifacts unchanged. It also corrects the FFI status reporting on success and extracts the graph input-parsing helpers into their own module.

## Graph witness path

The hardening follows the graph path end to end (`calc_witness` -> `calc_witness_graph` -> deserialize -> validate -> `evaluate`):

- **Decode.** The protobuf graph parser checks the metadata pointer, node lengths, and varints against the buffer with bounds-checked ranges, reporting `UnexpectedEof` for truncation and `InvalidData` for structurally invalid offsets. Unknown node field numbers and protobuf wire types are reported as errors.
- **Allocations.** Counts and lengths read from the artifact are reserved fallibly with `Vec::try_reserve` or read through a bounded `Read::take`, so an implausible value produces an error and cannot drive an out-of-memory abort. The V2 input metadata caps the single infallible component allocation at a fixed bound.
- **Node references.** A validation pass runs before evaluation and rejects any decoded node whose input, constant, or operand index is out of range, any operand that does not refer to a strictly earlier node, and any out-of-range witness output.
- **Input metadata (V2).** The input layout is validated for contiguity and arithmetic overflow; bus type indices are checked transitively with a cycle guard; each field's declared `base_type_size` is reconciled against the recursively computed size so the sizing and offset-placement models agree; and out-of-range root-array keys in the inputs JSON are bounds-checked.
- **Field operations.** `modulo` returns zero for a zero divisor, matching the existing `div` and `idiv` behavior, and the decoded graph prime is constrained to the supported fields (BN254 and Goldilocks), which keeps every modular inverse defined.

## FFI status reporting

`gw_calc_witness` reports a success status (`GW_ERROR_CODE_OK` with a null `error_msg`) when witness calculation succeeds; the success path previously left a placeholder error status. `prepare_status` null-checks the message allocation and publishes the pointer only after the copy completes, so a failed allocation leaves a null `error_msg`, and it skips the copy for an empty message.

## Refactoring

The graph input-parsing helpers (input-layout validation, the checked arithmetic, the V2 metadata checks, and the V1/V2 input builders) move from `lib.rs` into a new `graph_inputs` module. The functions are relocated without logic changes.

## Scope

This change covers the graph (`wtns.graph.*`) witness path. The CVM (`wtns.cvm.*`) interpreter path is addressed separately.

## Compatibility

No change to the `calc_witness` Rust API: it still returns `Result<Vec<u8>, Box<dyn std::error::Error>>`, and valid artifacts produce identical witnesses. The C header drops `const` from the `gw_status_t` pointer parameter of `gw_calc_witness`, reflecting that the function writes the status. This is a source-level change for C callers and does not affect the ABI.

## Validation

- `cargo test` passes (137 lib tests plus the bin suites), and `cargo clippy --lib` is clean.
- The graph path has regression tests that drive the public `calc_witness` under `catch_unwind` for each closed panic and abort vector, and the FFI success path has an end-to-end test asserting the OK status and witness output.
- The input-helper extraction preserves behavior: the relocated functions are exercised unchanged by the existing input-metadata and witness-calculation tests.
