### PR TITLE
build-circuit: fix three panics blocking a real ICAO 9303 passport-verification circuit

### DIFF
--- a/extensions/build-circuit/src/main.rs
+++ b/extensions/build-circuit/src/main.rs
@@ -1,6 +1,6 @@
 use compiler::circuit_design::template::TemplateCode;
 use compiler::compiler_interface::{run_compiler, Circuit, Config, VCP};
-use compiler::intermediate_representation::ir_interface::{AccessType, AddressType, BranchBucket, ComputeBucket, CreateCmpBucket, FinalData, InputInformation, Instruction, InstructionPointer, LoadBucket, LocationRule, ObtainMeta, OperatorType, ReturnBucket, ReturnType, SizeOption, StatusInput, StoreBucket, ValueBucket, ValueType};
+use compiler::intermediate_representation::ir_interface::{AccessType, AddressType, BranchBucket, CallBucket, ComputeBucket, CreateCmpBucket, FinalData, InputInformation, Instruction, InstructionPointer, LoadBucket, LocationRule, ObtainMeta, OperatorType, ReturnBucket, ReturnType, SizeOption, StatusInput, StoreBucket, ValueBucket, ValueType};
 use constraint_generation::{build_circuit, BuildConfig};
 use program_structure::error_definition::Report;
 use std::collections::{BTreeMap, BTreeSet};
@@ -1754,6 +1754,79 @@ fn store_function_variable<T: FieldOps + 'static, NS: NodesStorage + 'static>(
     (v, lvar_idx)
 }
 
+// Runs a function call that is itself the single instruction of a ternary
+// operation's if/else branch (e.g. `ret = someFn(...)` inside a signal-
+// dependent `if`). Mirrors store_function_variable's contract/signature so
+// both can be used interchangeably by the ternary-branch matcher below, but
+// where store_function_variable pulls (Var, lvar_idx) out of a plain
+// Instruction::Store, this evaluates the call (same logic as the
+// Instruction::Call arm of process_function_instruction) and pulls
+// (Var, lvar_idx) out of its ReturnType::Final destination info instead of
+// writing the call's result into fn_vars directly - the caller still needs
+// the raw Var to combine with the other branch into a TernCond node first.
+fn call_function_for_ternary<T: FieldOps + 'static, NS: NodesStorage + 'static>(
+    ctx: &mut BuildCircuitContext<T, NS>, call_bucket: &CallBucket,
+    fn_vars: &mut Vec<Option<Var<T>>>, call_stack: &Vec<String>) -> (Var<T>, usize) {
+
+    let mut new_fn_vars: Vec<Option<Var<T>>> = vec![None; call_bucket.arena_size];
+
+    let mut count: usize = 0;
+    for (idx, inst2) in call_bucket.arguments.iter().enumerate() {
+        let arg_size =
+            expect_single_size(&call_bucket.argument_types[idx].size);
+        let args = calc_function_expression_n(
+            inst2, fn_vars, ctx.nodes, arg_size, call_stack);
+        for arg in args {
+            new_fn_vars[count] = Some(arg);
+            count += 1;
+        }
+    }
+
+    let r = run_function(ctx, &call_bucket.symbol, &mut new_fn_vars, call_stack);
+
+    let final_data = match call_bucket.return_info {
+        ReturnType::Intermediate { .. } => {
+            panic!(
+                "intermediate return is not supported for a function call \
+                 inside a ternary operation branch: {}",
+                call_stack.join(" -> "));
+        }
+        ReturnType::Final(ref final_data) => final_data,
+    };
+
+    assert!(matches!(final_data.dest_address_type, AddressType::Variable),
+            "functions can store only inside variables: dest_address_type: {}",
+            final_data.dest_address_type.to_string());
+
+    let (location, template_header) = match &final_data.dest {
+        LocationRule::Indexed { location, template_header } => (location, template_header),
+        LocationRule::Mapped { .. } => {
+            panic!("location rule supposed to be Indexed for variables");
+        }
+    };
+
+    let lvar_idx = calc_function_expression(location, fn_vars, ctx.nodes, call_stack)
+        .must_const_usize(ctx.nodes, call_stack);
+
+    let dest_size = expect_single_size(&final_data.context.size);
+    assert_eq!(
+        dest_size, 1,
+        "variable size in ternary expression must be 1: {}, {}:{}",
+        template_header.as_ref().unwrap_or(&"-".to_string()),
+        call_stack.join(" -> "), call_bucket.get_line());
+
+    let v = match r {
+        FnReturn::FnVar { idx, ln } => {
+            assert_eq!(ln, 1);
+            new_fn_vars[idx].clone().unwrap_or_else(|| panic!(
+                "return value is not set {}: {}", idx, call_stack.join(" -> ")))
+        }
+        FnReturn::Value(v) => v,
+    };
+
+    (v, lvar_idx)
+}
+
 fn process_function_instruction<T, NS>(
     ctx: &mut BuildCircuitContext<T, NS>, inst: &InstructionPointer,
     fn_vars: &mut Vec<Option<Var<T>>>,
@@ -1856,6 +1929,10 @@ where
                             store_function_variable(
                                 store_bucket, fn_vars, ctx.nodes, call_stack)
                         }
+                        Instruction::Call(ref call_bucket) => {
+                            call_function_for_ternary(
+                                ctx, call_bucket, fn_vars, call_stack)
+                        }
                         Instruction::Return(ref return_bucket) => {
                             let ret = build_return(
                                 return_bucket, fn_vars, ctx.nodes, call_stack);
@@ -1908,6 +1985,10 @@ where
                             Instruction::Store(ref store_bucket) => {
                                 store_function_variable(
                                     store_bucket, fn_vars, ctx.nodes, call_stack)
+                            }
+                            Instruction::Call(ref call_bucket) => {
+                                call_function_for_ternary(
+                                    ctx, call_bucket, fn_vars, call_stack)
                             }
                             _ => {
                                 panic!(

--- a/extensions/build-circuit/src/main.rs
+++ b/extensions/build-circuit/src/main.rs
@@ -181,7 +181,15 @@ where
     T: FieldOps + 'static,
     NS: NodesStorage + 'static {
 
-    assert!(size > 0, "size = {}", size);
+    if size == 0 {
+        // A zero-length array signal store is legitimate circom (e.g. a
+        // subcomponent input sized by a constant that evaluates to 0, such
+        // as DG15_BLOCK_NUMBER=0 in passport-zk-circuits' "_NA" variants).
+        // Every call site below treats a size-0 fetch as a no-op already
+        // (the `for i in 0..size` loops just don't run), so short-circuit
+        // here instead of asserting.
+        return vec![];
+    }
 
     if size == 1 {
         // operator_argument_instruction implements much more cases than
@@ -266,12 +274,21 @@ where
 
                     let mut result = Vec::with_capacity(size);
                     for i in 0..size {
-                        let signal_node = ctx.signal_node_idx[signal_idx + i];
-                        assert_ne!(
-                            signal_node, usize::MAX,
-                            "signal {}/{}/{} is not set yet",
-                            cmp.signal_offset, signal_idx, i);
-                        result.push(signal_node);
+                        let idx = signal_idx + i;
+                        // A subcomponent output signal can be genuinely
+                        // unset here: some templates (e.g. recursive
+                        // base cases sized to a compile-time constant)
+                        // legitimately never assign every index of an
+                        // output array on every instantiation. Real
+                        // circom's own witness generators leave such
+                        // slots at their buffer's default (0); mirror
+                        // that instead of asserting, matching the
+                        // AddressType::Signal load path just above.
+                        if ctx.signal_node_idx[idx] == usize::MAX {
+                            ctx.signal_node_idx[idx] =
+                                ctx.nodes.const_node_idx_from_value(T::zero());
+                        }
+                        result.push(ctx.signal_node_idx[idx]);
                     }
                     result
                 }
@@ -584,9 +601,16 @@ where
                     }
 
                     let signal_idx = signal_offset + signal_idx;
-                    let signal_node = ctx.signal_node_idx[signal_idx];
-                    assert_ne!(signal_node, usize::MAX, "signal is not set yet");
-                    signal_node
+                    // See the size-N load path above: a subcomponent
+                    // output can be legitimately never-assigned for a
+                    // given instantiation; default to the constant-0
+                    // node like real circom's own witness generators do,
+                    // rather than asserting.
+                    if ctx.signal_node_idx[signal_idx] == usize::MAX {
+                        ctx.signal_node_idx[signal_idx] =
+                            ctx.nodes.const_node_idx_from_value(T::zero());
+                    }
+                    ctx.signal_node_idx[signal_idx]
                 }
                 AddressType::Variable => {
                     match load_bucket.src {

--- a/test_circuits/circuit26_zero_length_array_store.circom
+++ b/test_circuits/circuit26_zero_length_array_store.circom
@@ -1,0 +1,30 @@
+pragma circom 2.0.0;
+
+// Regression test: a subcomponent input array sized 0 is a legitimate,
+// no-op circom construct (e.g. a passport-verification circuit variant
+// with no DG15/active-authentication support declares
+// `signal input dg15[0]`). Storing a zero-length array signal into it via
+// `<==` must not panic during witness-graph construction.
+template Sub(N) {
+    signal input arr[N];
+    signal output out;
+
+    var sum = 0;
+    for (var i = 0; i < N; i++) {
+        sum += arr[i];
+    }
+    out <== sum;
+}
+
+template Main() {
+    signal input x;
+    signal input emptyArr[0];
+    signal output out;
+
+    component sub = Sub(0);
+    sub.arr <== emptyArr;
+
+    out <== x + sub.out;
+}
+
+component main = Main();

--- a/test_circuits/circuit27_unset_subcomponent_signal.circom
+++ b/test_circuits/circuit27_unset_subcomponent_signal.circom
@@ -1,0 +1,36 @@
+pragma circom 2.0.0;
+
+// Regression test: a subcomponent output array signal where only some
+// indices are ever assigned (e.g. a recursive template's base case that
+// writes out[0] but never out[1] on that particular instantiation,
+// matching passport-zk-circuits' KaratsubaOverflow(1)). Real circom's own
+// witness generators leave the untouched index at its buffer default (0);
+// witness-graph construction must do the same on both the single-signal
+// and array-load paths, instead of panicking on a "signal not set" read.
+template Leaf() {
+    signal input a;
+    signal input b;
+    signal output out[2];
+
+    out[0] <== a * b;
+    // out[1] intentionally left unassigned
+}
+
+template Main() {
+    signal input a;
+    signal input b;
+    signal output single;
+    signal output bulk[2];
+
+    component leaf1 = Leaf();
+    leaf1.a <== a;
+    leaf1.b <== b;
+    single <== leaf1.out[0] + leaf1.out[1];
+
+    component leaf2 = Leaf();
+    leaf2.a <== a;
+    leaf2.b <== b;
+    bulk <== leaf2.out;
+}
+
+component main = Main();

--- a/test_circuits/circuit28_ternary_call_branch.circom
+++ b/test_circuits/circuit28_ternary_call_branch.circom
@@ -1,0 +1,47 @@
+pragma circom 2.0.0;
+
+// Regression test: a signal-dependent (dynamic) `if`/`else` inside a
+// circom `function`, where each branch's single statement is a function
+// call rather than a plain expression (e.g. passport-zk-circuits'
+// `short_div`: `if (norm_b[k] != 0) { ret = short_div_norm(...); } else
+// { ret = short_div_norm(...); }`, both branches calling a helper
+// function). This exercises the ternary-branch lowering used when the
+// condition can't be resolved to a compile-time constant.
+//
+// Note: `out` uses `<--` rather than `<==` because real circom's own
+// degree checker (T3001 "non quadratic constraints") conservatively
+// rejects binding a value returned from a function containing a dynamic
+// ternary directly into a `<==`, regardless of the value's actual
+// algebraic degree - a pre-existing circom front-end quirk, unrelated to
+// build-circuit. `<--` reproduces the ternary/Call defect this commit
+// fixes (both branches run to completion instead of panicking on
+// "expected store operation in ternary operation") and then separately
+// hits build-circuit's pre-existing, distinct `todo!("Signal")` in
+// store_function_return_results for AddressType::Signal - a real gap,
+// but not this bug; not attempted here.
+function double(x) {
+    return x * 2;
+}
+
+function triple(x) {
+    return x * 3;
+}
+
+function pick(cond, x) {
+    var ret;
+    if (cond != 0) {
+        ret = double(x);
+    } else {
+        ret = triple(x);
+    }
+    return ret;
+}
+
+template Main() {
+    signal input cond;
+    signal output out;
+
+    out <-- pick(cond, 5);
+}
+
+component main = Main();


### PR DESCRIPTION
## Summary

Three panics in `build-circuit`'s witness-graph construction, each found by fixing the previous one and re-running against the same real, unmodified circuit: `registerIdentity_11_256_3_2_336_216_NA` from [rarimo/passport-zk-circuits](https://github.com/rarimo/passport-zk-circuits) (RSA-2048-PSS-SHA256 ICAO 9303 passport signature verification — 678,158 non-linear constraints, 650,565 wires). All three are legitimate, real-world circom constructs that circom's own reference witness generators (wasm/cpp) handle via implicit defaults; `build-circuit` hard-asserted instead.

## Bug 1: zero-length array signal store

`operator_argument_instruction_n` (`extensions/build-circuit/src/main.rs`) unconditionally asserted `size > 0` before processing a multi-element argument fetch. A subcomponent input array sized 0 by a template parameter (e.g. `signal input dg15[DG15_BLOCK_NUMBER * HASH_BLOCK_SIZE]` with `DG15_BLOCK_NUMBER=0` in passport-zk-circuits' `_NA` variants) is legitimate, valid circom — every call site already treats a size-0 fetch as a no-op, so this short-circuits to `vec![]` instead of asserting.

## Bug 2: unset subcomponent output signal read

Two `SubcmpSignal` load sites asserted the target signal must already be set (`assert_ne!(signal_node, usize::MAX, "signal is not set yet")`). This fires for a subcomponent output array where only some indices are ever assigned on a given instantiation — e.g. passport-zk-circuits' `KaratsubaOverflow(1)` base case (used recursively for RSA-2048 modular multiplication), which assigns `out[0]` of its 2-element `out` array but never `out[1]`:

```circom
template KaratsubaOverflow(CHUNK_NUMBER) {
    signal output out[2 * CHUNK_NUMBER];
    if (CHUNK_NUMBER == 1) {
        out[0] <== in[0][0] * in[1][0];
        // out[1] never assigned
    } else { ... }
}
```

Verified against real circom 2.2.3's own wasm witness calculator on an equivalent minimal circuit: it computes `0` for the never-assigned index (the signal buffer's default), no compile error, no warning. `build-circuit` already has this exact default-to-zero behavior for the plain `AddressType::Signal` load path a few lines above each of these two sites — this extends the same pattern to `AddressType::SubcmpSignal` loads.

## Bug 3: function call as a ternary branch's single statement

The dynamic-condition ("ternary") branch handling in `process_function_instruction` only recognized a branch instruction that's a plain `Store` or a `Return`. Real code also has branches whose one statement is a function call whose result is assigned directly:

```circom
// bigIntFunc.circom's short_div, used in RSA modular reduction
if (norm_b[k] != 0) {
    ret = short_div_norm(n, k + 1, norm_a, norm_b);
} else {
    ret = short_div_norm(n, k, norm_a, norm_b);
}
```

circom's IR represents `ret = someFn(...)` as a single `Call` instruction with its destination embedded in `return_info` (`ReturnType::Final`), not wrapped in a separate `Store` — so it fell through to the "expected store operation" panic.

Fixed by adding `call_function_for_ternary()`, which evaluates the call using the same logic as the file's existing general-purpose `Instruction::Call` handler, then extracts `(Var, lvar_idx)` from the `ReturnType::Final` destination info the same way `store_function_variable()` does for a plain `Store` — so both branch kinds combine into a `TernCond` node identically. Wired into both the if-branch and else-branch match arms.

## Testing

Added three minimal regression circuits (`test_circuits/circuit26_zero_length_array_store.circom`, `circuit27_unset_subcomponent_signal.circom`, `circuit28_ternary_call_branch.circom`). Verified each:
- panics on the pre-fix binary at the same assertion the real circuit hits (confirmed via `git stash`)
- succeeds (or, for circuit27/28, runs to completion past the relevant instruction) on the post-fix binary
- matches real circom 2.2.3's own compiler + wasm witness calculator output for the equivalent pattern where applicable

Also re-ran the full real-world repro circuit end-to-end after each fix. With all three applied, `build-circuit` now runs well past where it used to panic — through the complete RSA-2048 modular-reduction pipeline (`BigMultOverflow` → `reduce_overflow` → `long_div` → `short_div` → nested `short_div_norm`/`long_gt`/`long_scalar_mult` calls) — before hitting a fourth, separate, and larger issue (a nested multi-statement dynamic branch, which the ternary lowering doesn't support at all — needs a bigger generalization than a scoped patch). Not included in this PR; will file separately once diagnosed further.
